### PR TITLE
Converted unitsPerJobs in a mandatory parameter

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -30,7 +30,7 @@ mapping = {
                             "blockwhitelist"    : {"default": None,             "config": 'Data.blockWhitelist',    "type": "ListType",    "required": False},
                             "blockblacklist"    : {"default": None,             "config": 'Data.blockBlacklist',    "type": "ListType",    "required": False},
                             "splitalgo"         : {"default": None,             "config": 'Data.splitting',         "type": "StringType",  "required": False},
-                            "algoargs"          : {"default": None,             "config": 'Data.unitsPerJob',       "type": "IntType",  "required": False},
+                            "algoargs"          : {"default": None,             "config": 'Data.unitsPerJob',       "type": "IntType",  "required": True},
                             "addoutputfiles"    : {"default": [],               "config": 'JobType.outputFiles',    "type": "ListType",    "required": False},
                             "blacklistT1"       : {"default": True,             "config": None,                     "type": "BooleanType", "required": False},
                           },


### PR DESCRIPTION
From one of Marco-Andrea issues: he got a "Incorrect 'algoargs' parameter" because the parameter was optional in the client and mandatory in the server
