### PR TITLE
Adding hash to publish data name

### DIFF
--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -130,14 +130,15 @@ class submit(SubCommand, ConfigCommand):
         if getattr(self.configuration.JobType, 'pluginName', None) is not None:
             jobtypes    = getJobTypes()
             plugjobtype = jobtypes[upper(self.configuration.JobType.pluginName)](*pluginParams)
-            inputfiles, jobconfig = plugjobtype.run(configreq)
+            inputfiles, jobconfig, isbchecksum = plugjobtype.run(configreq)
         else:
             fullname = self.configuration.JobType.externalPluginFile
             basename = os.path.basename(fullname).split('.')[0]
             plugin = addPlugin(fullname)[basename]
             pluginInst = plugin(*pluginParams)
-            inputfiles, jobconfig = pluginInst.run(configreq)
+            inputfiles, jobconfig, isbchecksum = pluginInst.run(configreq)
 
+        configreq['publishname'] = "%s-%s" %(configreq['publishname'], isbchecksum)
         configreq.update(jobconfig)
 
         server = HTTPRequests(self.serverurl, self.proxyfilename)

--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -78,6 +78,7 @@ class Analysis(BasicJobType):
         self.logger.debug("Result uploading input files: %s " % str(uploadResults))
         configArguments['cachefilename'] = uploadResults[1]
         configArguments['cacheurl'] = uploadResults[0]
+        isbchecksum = uploadResults[2]
 
         # Upload lumi mask if it exists
         lumiMaskName = getattr(self.config.Data, 'lumiMask', None)
@@ -93,7 +94,7 @@ class Analysis(BasicJobType):
 
         configArguments['jobtype'] = 'Analysis'
 
-        return tarFilename, configArguments
+        return tarFilename, configArguments, isbchecksum
 
 
     def validateConfig(self, config):

--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -118,7 +118,7 @@ class UserTarball(object):
         #                                  "proxyfilename" : self.config.JobType.proxyfilename, "capath" : self.config.JobType.capath, "newrest" : True})
 
         #return ufc.upload(self.tarfile.name)
-        return serverUrl, archiveName
+        return serverUrl, archiveName, self.checksum
 
     def calculateChecksum(self):
         """


### PR DESCRIPTION
The hash is done with sha256 (as before), that is why it is very long. It's safer then sha1, but if sha256 is too long we could use sha1, and I still believe that conflicts will be rare.

Signed-off-by: cinquo m.cinquilli@gmail.com
