### PR TITLE
Remove deprecated stuff from crabclient, such as conficacheurl or ufccacheurl

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -38,11 +38,11 @@ mapping = {
                           },
 
                   'other-config-params' : [
-                                           "General.serverUrl", "General.ufccacheUrl", "General.requestName", "General.workArea",
+                                           "General.serverUrl", "General.requestName", "General.workArea",
                                            "JobType.pluginName", "JobType.externalPluginFile", "JobType.psetName",
                                            "JobType.inputFiles", "JobType.pyCfgParams",
                                            "Data.unitsPerJob", "Data.splitting", "Data.inputDataset", "Data.lumiMask", "Data.runRange",
-                                           "User.email", "Site.removeT1Blacklisting", "General.configcacheUrl" , "General.configcacheName"
+                                           "User.email", "Site.removeT1Blacklisting"
                                           ],
                   'requiresTaskOption' : False
                 },

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -43,16 +43,8 @@ class submit(SubCommand, ConfigCommand):
             self.serverurl = self.options.server
         elif getattr( self.configuration.General, 'serverUrl', None ) is not None:
             self.serverurl = self.configuration.General.serverUrl
-#TODO: For sure the server url should not be handled here. Find an intelligent way for this
         else:
             self.serverurl = 'http://cmsweb.cern.ch'
-        if not hasattr( self.configuration.General, 'ufccacheUrl' ):
-            self.configuration.General.ufccacheUrl = self.serverurl
-        if not hasattr( self.configuration.General, 'configcacheUrl' ):
-            #https is required because configcache does not use ServerInteractions
-            self.configuration.General.configcacheUrl = 'https://' + self.serverurl + '/couchdb'
-        if not hasattr( self.configuration.General, 'configcacheName' ):
-            self.configuration.General.configcacheName = 'analysis_reqmgr_config_cache'
 
         self.createCache( self.serverurl )
 


### PR DESCRIPTION
as summary.
