### PR TITLE
For privateMC, do not accept inputDataset but only primaryDataset.

### DIFF
--- a/src/python/CRABClient/JobType/PrivateMC.py
+++ b/src/python/CRABClient/JobType/PrivateMC.py
@@ -26,8 +26,6 @@ class PrivateMC(Analysis):
             if not re.match("/%(primDS)s.*" % WMCore.Lexicon.lfnParts, primDS):
                 self.logger.warning("Invalid primary dataset name %s for private MC; publishing may fail" % primDS)
             configArguments['inputdata'] = primDS
-        elif getattr(self.config.Data, 'inputDataset', None):
-            configArguments['inputdata'] = self.config.Data.inputDataset
         else:
             configArguments['inputdata'] = "/CRAB_PrivateMC"
 


### PR DESCRIPTION
This is to fix https://github.com/dmwm/CRABServer/issues/4292. I am not sure if we should add a check that primaryDataset has been provided.. Currently, if not provided, we use "/CRAB_PrivateMC" for configArguments['inputdata'].
