### PR TITLE
In case of a config parameter error, report the client parameter name in...

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -24,6 +24,7 @@ from socket import error as SocketError
 from CRABClient import __version__ as client_version
 from CRABClient.client_utilities import getAvailCommands
 from CRABClient.client_exceptions import ClientException
+from CRABClient.ClientMapping import mapping
 
 
 class MyNullHandler(logging.Handler):
@@ -192,7 +193,16 @@ if __name__ == "__main__":
         if he.headers.has_key('X-Error-Detail'):
             client.logger.info('Server answered with: %s' % he.headers['X-Error-Detail'])
         if he.headers.has_key('X-Error-Info'):
-            client.logger.info('Reason is: %s' % he.headers['X-Error-Info'])
+            reason = he.headers['X-Error-Info']
+            for parname in mapping['submit']['map'].keys():
+                for tmpmsg in ['\''+parname+'\' parameter','Parameter \''+parname+'\'']:
+                    if tmpmsg in reason:
+                        reason = reason.replace(tmpmsg,tmpmsg.replace(parname,mapping['submit']['map'][parname]['config']))
+                        break
+                else:
+                    continue
+                break
+            client.logger.info('Reason is: %s' % reason)
         #The following goes to the logfile.
         errmsg = "ERROR: %s (%s): " % (he.reason, he.status)
         ## answer can be a json or not


### PR DESCRIPTION
...stead of the server parameter name. This is for issue #4121. 

Here is the output I got form a test:

Sending the request to the server
Error contacting the server.
Server answered with: Invalid input parameter
Reason is: Invalid 'General.transferOutput' parameter

The fix recognizes two kind of error messages:
1) "Parameter '<parname>'"
2) "'<parname>' parameter"
and replaces the <parname> by its client counterpart.
These two cases should cover most (if not all) of the InvalidParameter exception error messages that contain a parameter name (see src/python/WMCore/REST/Validation.py).
