### PR TITLE
Use non-empty file in checkwrite. Improve checkwrite messages.

### DIFF
--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -1,5 +1,6 @@
 import subprocess
-from os import path , remove
+from os import path, remove
+import datetime
 
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.client_utilities import colors
@@ -11,110 +12,139 @@ class checkwrite(SubCommand):
     """
       let user to test if he/she have permission to write on specify site
     """
-    name ='checkwrite'
+    name = 'checkwrite'
     shortnames = ['chk']
 
 
     def __call__(self):
 
-        self.filename ='crab3chkwrite.tmp'
+        self.filename = 'crab3checkwrite.tmp'
+
         self.username = self.proxy.getHyperNewsName()
-        phedex = PhEDEx({"cert":self.proxyfilename, "key":self.proxyfilename})
+        phedex = PhEDEx({"cert": self.proxyfilename, "key": self.proxyfilename})
 
         if hasattr(self.options, 'userlfn') and self.options.userlfn != None:
-            lfnsadd = self.options.userlfn +'/'+ self.filename
+            lfnsadd = self.options.userlfn + '/' + self.filename
         else:
-            lfnsadd = '/store/user/'+self.username+'/'+self.filename
+            lfnsadd = '/store/user/' + self.username + '/' + self.filename
 
         try:
-            pfndict=phedex.getPFN(nodes = [self.options.sitename], lfns = [lfnsadd])
-            pfn = pfndict[(self.options.sitename,lfnsadd)]
-            if pfn == None:
-                self.logger.info('%sError%s: Failed to get pfn from the site, Please check site status' % (colors.RED, colors.NORMAL) )
+            pfndict = phedex.getPFN(nodes = [self.options.sitename], lfns = [lfnsadd])
+            pfn = pfndict[(self.options.sitename, lfnsadd)]
+            if not pfn:
+                self.logger.info('%sError%s: Failed to get PFN from the site. Please check the site status' % (colors.RED, colors.NORMAL))
                 raise ConfigurationException
         except HTTPException, errormsg :
             self.logger.info('%sError:%s Failed to contact PhEDEx or wrong PhEDEx node name is use' %(colors.RED, colors.NORMAL))
             self.logger.info('Result: %s\nStatus :%s\nurl :%s' % (errormsg.result, errormsg.status, errormsg.url))
             raise HTTPException, errormsg
 
+        self.logger.info('Attempting to copy file %s to site %s' % (self.filename, self.options.sitename))
         cpout, cperr, cpexitcode = self.lcgcp(pfn)
 
         if cpexitcode == 0:
-            delexitcode=self.lcgdelete(pfn)
+            self.logger.info('Successfully copied file %s to site %s' % (self.filename, self.options.sitename))
+            self.logger.info('Attempting to delete file %s from site %s' % (pfn, self.options.sitename))
+            delexitcode = self.lcgdelete(pfn)
+            if delexitcode:
+                self.logger.info('Warning: Failed to delete file %s from site %s' % (pfn, self.options.sitename))
+            else:
+                self.logger.info('Successfully deleted file %s from site %s' % (pfn, self.options.sitename))
             exitcode = 0
-
+        elif 'Permission denied' in cperr or 'mkdir: cannot create directory' in cperr:
+            exitcode = 1
         elif 'timeout' in cpout or 'timeout' in cperr:
             self.logger.info("%sError: %sConnection time out, try again later" %(colors.RED, colors.NORMAL))
-            exitcode = 1
+            exitcode = -1
         elif 'exist' in cpout or 'exist' in cperr:
-            exitcode = 1
-            self.logger.info('Attempting to delete %s on site' % self.filename)
-            delexitcode=self.lcgdelete(pfn)
-            if delexitcode == 0:
-                self.logger.info('Attempting to write on site again')
-                cpout, cperr, cpexitcode=self.lcgcp(pfn)
-
+            self.logger.info('Error copying file %s to site %s, it may be that file already exists' % (self.filename, self.options.sitename))
+            self.logger.info('Attempting to delete file %s from site %s' % (pfn, self.options.sitename))
+            delexitcode = self.lcgdelete(pfn)
+            if delexitcode:
+                self.logger.info('Failed to delete file %s from site %s' % (pfn, self.options.sitename))
+                exitcode = -1
+            else:
+                self.logger.info('Successfully deleted file %s from site %s' % (pfn, self.options.sitename))
+                self.logger.info('Attempting to copy file %s to site %s again' % (self.filename, self.options.sitename))
+                cpout, cperr, cpexitcode = self.lcgcp(pfn)
                 if cpexitcode == 0:
-                    delexitcode=self.lcgdelete(pfn)
+                    self.logger.info('Successfully copied file %s to site %s' % (self.filename, self.options.sitename))
+                    self.logger.info('Attempting to delete file %s from site %s' % (pfn, self.options.sitename))
+                    delexitcode = self.lcgdelete(pfn)
+                    if delexitcode:
+                        self.logger.info('Failed to delete file %s from site %s' % (pfn, self.options.sitename))
+                    else:
+                        self.logger.info('Successfully deleted file %s from site %s' % (pfn, self.options.sitename))
                     exitcode = 0
+                else:
+                    exitcode = 1
         else:
             exitcode = 1
 
         if exitcode == 0:
-            self.logger.info("%sSuccess%s: Successfully write on site %s" %(colors.GREEN, colors.NORMAL, self.options.sitename))
-        elif exitcode != 0:
-            self.logger.info("%sError%s: Unable to write on site %s" % (colors.RED, colors.NORMAL, self.options.sitename))
+            self.logger.info('%sSuccess%s: Able to write on site %s' % (colors.GREEN, colors.NORMAL, self.options.sitename))
+        elif exitcode == -1:
+            self.logger.info('Unable to check write permission on site %s' % self.options.sitename)
+        else:
+            self.logger.info('%sError%s: Unable to write on site %s' % (colors.RED, colors.NORMAL, self.options.sitename))
 
 
-
-
-    def lcgcp(self, pfn ):
+    def lcgcp(self, pfn):
 
         try:
-            file = open(self.filename,'w')
-            file.close()
+            with open(self.filename, 'w') as file:
+                file.write('This is a dummy file created by the crab checkwrite command on %s' % str(datetime.datetime.now().strftime('%d/%m/%Y at %H:%M:%S')))
         except IOError:
-            self.logger.info("%sError%s:  failed to create local %s" % (colors.RED,colors.NORMAL,self.filename))
+            self.logger.info('%sError%s: Failed to create file %s' % (colors.RED, colors.NORMAL, self.filename))
             raise Exception
 
-        abspath=path.abspath(self.filename)
+        abspath = path.abspath(self.filename)
 
-        cpcmd ="lcg-cp -v -b -D srmv2 --connect-timeout 180 " + abspath +' '+ pfn
-        self.logger.info("Attempting to write on site: %s \nExecuting the command: %s\nPlease wait" %(self.options.sitename, cpcmd))
-        cpprocess = subprocess.Popen(cpcmd, stdout= subprocess.PIPE, stderr= subprocess.PIPE, shell= True)
-        cpout , cperr = cpprocess.communicate()
+        cpcmd = 'lcg-cp -v -b -D srmv2 --connect-timeout 180 ' + abspath + ' ' + pfn
+        self.logger.info('Executing command: %s' % cpcmd)
+        self.logger.info('Please wait...')
+        cpprocess = subprocess.Popen(cpcmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
+        cpout, cperr = cpprocess.communicate()
         cpexitcode = cpprocess.returncode
 
-        if cpexitcode != 0 :
-            self.logger.info("%sError%s: Error in lcg-cp \nStdout: \n%s\nStderr: \n%s" %(colors.RED,colors.NORMAL,cpout,cperr))
-        elif cpexitcode == 0 :
-            self.logger.info("%sSuccess%s: Successfully run lcg-cp" %(colors.GREEN, colors.NORMAL))
+        if cpexitcode:
+            self.logger.info('Failed running lcg-cp')
+            if cpout:
+                self.logger.info('  Stdout:\n    %s' % cpout.replace('\n','\n    '))
+            if cperr:
+                self.logger.info('  Stderr:\n    %s' % cperr.replace('\n','\n    '))
+        else:
+            self.logger.info('Successfully ran lcg-cp')
 
         try:
             remove(abspath)
         except Exception:
-            self.logger.info("%sError%s: Failed in deleting local %s" % self.filename)
+            self.logger.info('%sError%s: Failed to delete file %s' % (colors.RED, colors.NORMAL, self.filename))
             pass
 
         return cpout, cperr, cpexitcode
 
-    def lcgdelete(self,pfn):
 
-        self.logger.info("Deleting file: %s" %pfn)
-        rmcmd ="lcg-del --connect-timeout 180 -b  -l -D srmv2 "+pfn
-        self.logger.info("Executing command: %s" % rmcmd)
-        delprocess = subprocess.Popen(rmcmd, stdout= subprocess.PIPE, stderr= subprocess.PIPE, shell=True)
+    def lcgdelete(self, pfn):
+
+        rmcmd = 'lcg-del --connect-timeout 180 -b -l -D srmv2 ' + pfn
+        self.logger.info('Executing command: %s' % rmcmd)
+        self.logger.info('Please wait...')
+        delprocess = subprocess.Popen(rmcmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
         delout, delerr = delprocess.communicate()
         delexitcode = delprocess.returncode
 
-        if delexitcode != 0:
-            self.logger.info("%sError%s:  Failed in running lcg-del\nStdout:\n%s\nStderr:\n%s" \
-                             % (colors.RED, colors.NORMAL, delout, delerr))
-        elif delexitcode == 0 :
-            self.logger.info("%sSuccess%s: Successfully run lcg-del" %(colors.GREEN, colors.NORMAL))
+        if delexitcode:
+            self.logger.info('Failed running lcg-del')
+            if delout:
+                self.logger.info('  Stdout:\n    %s' % delout.replace('\n','\n    '))
+            if delerr:
+                self.logger.info('  Stderr:\n    %s' % delerr.replace('\n','\n    '))
+        else:
+            self.logger.info('Successfully ran lcg-del')
 
         return delexitcode
-#return exit code
+
 
     def setOptions(self):
         """
@@ -133,6 +163,6 @@ class checkwrite(SubCommand):
     def validateOptions(self):
         SubCommand.validateOptions(self)
 
-        if not hasattr(self.options,'sitename') or self.options.sitename is None:
-            self.logger.info("Missing site name, use '--site' options")
+        if not hasattr(self.options, 'sitename') or self.options.sitename is None:
+            self.logger.info("Missing site name, use '--site' option")
             raise MissingOptionException


### PR DESCRIPTION
Notice that most of the changes are cosmetic.

The one relevant change is to use a non-empty file in lcg-cp. Plus I improved a bit (IMO) the interpretation of the lcg-cp errors and the output messages to the user. When I say that I improved the interpretation of the lcg-cp errors, I mean that:
I ask if the err message from lcg-cp contains either "Permission denied" or "mkdir: cannot create directory" and in that case I set exitcode = 1 and that's it, the user does not have write permission. Otherwise we do the check that was done before: if the err or out messages from lcg-cp contain "exist", we assume the message means that the destination file already exists, try to delete it and try lcg-cp again. I also changed the exitcode to -1 for a timeout in lcg-cp, and in that case we don't print "Error: Unable to write on site <sitename>", but "Unable to check write permission on site <sitename>".
Thus, at the end of the checkwrite, the command prints either:
- "Error: Unable to write on site <sitename>", or
- "Success: Able to write on site <sitename>", or
- "Unable to check write permission on site <sitename>".

I did crab checkwrite on all T2 sites plus T3_US_FNALLPC (in total 54 sites), and I get success in 37 of them. From the other 17 sites, the Malaysian site T2_MY_UPM_BIRUNI (I guess is not operational yet?) gives me
"Error: Failed to get PFN from the site. Please check the site status"
From the other 16 sites, I consider that 12 of them (T2_BR_UERJ, T2_DE_DESY, T2_ES_CIEMAT, T2_FI_HIP, T2_FR_GRIF_LLR, T2_TH_CUNSTDA, T2_UK_London_IC, T2_US_Caltech, T2_US_Florida, T2_US_Purdue, T2_US_UCSD, T3_US_FNALLPC) are correctly reported by the checkwrite command as "Error: Unable to write on site <sitename>", because the err message from the lcg-cp contains the phrase "Permission denied" and/or "mkdir: cannot create directory".  Then, there are 4 sites (T2_BE_UCL, T2_GR_Ioannina, T2_IT_Bari, T2_RU_SINP) where the err message from lcg-cp doesn't contain "Permission denied" or "mkdir: cannot create directory", and I don't know if concluding that the user has no write permission is correct or not, but we still print "Error: Unable to write on site <sitename>".

I put the outputs that I got from the crab checkwrite test for all sites in a file in /afs/cern.ch/user/a/atanasi/public/checkwrite_test/checkwrite_all_sites.txt
You can look at it yourself.
