### PR TITLE
Improve checkwrite messages to user.

### DIFF
--- a/src/python/CRABClient/client_utilities.py
+++ b/src/python/CRABClient/client_utilities.py
@@ -21,15 +21,19 @@ from CRABClient.client_exceptions import TaskNotFoundException, CachefileNotFoun
 
 class colors:
     if sys.stdout.isatty():
-        RED = '\033[91m'
-        GREEN = '\033[92m'
-        GRAY = '\033[90m'
+        RED    = '\033[91m'
+        GREEN  = '\033[92m'
+        BLUE   = '\033[93m'
+        GRAY   = '\033[90m'
         NORMAL = '\033[0m'
+        BOLD   = '\033[1m'
     else:
+        RED    = ''
+        GREEN  = ''
+        BLUE   = ''
+        GRAY   = ''
         NORMAL = ''
-        RED = ''
-        GREEN = ''
-        GRAY = ''
+        BOLD   = ''
 
 
 def getPlugins(namespace, plugins, skip):


### PR DESCRIPTION
I tried it on all T2 sites and the output is in /afs/cern.ch/user/a/atanasi/public/checkwrite_test/checkwrite_all_sites_new.txt
The main thing I wanted to improve is that we shouldn't tell to the user "Error: Unable to write on site <sitename>" when the error is not conclusive in that respect. Instead we now print:

Unable to check write permission on site <sitename>
Please try again later or contact the site administrators sending them the 'crab checkwrite' output as printed above

Still, when the stderr from lcg-cp contains "Permission denied" or "mkdir: cannot create directory" we do print "Error: Unable to write on site <sitename>", because I think that is conclusive. But we also print "You may want to contact the site administrators sending them the 'crab checkwrite' output as printed above"

And whatever the result of the checkwrite is, we print at the end the following note:
"NOTE: Please be responsible - don't write into a site where you didn't ask permission"

I also improved the code by putting some parts into functions, and by putting the checkwrite algorithm inside a while loop so that we can consider retries in the future.
