### PR TITLE
Add warning message that non-EDM files will not be published

### DIFF
--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -196,12 +196,6 @@ class SubCommand(ConfigCommand):
                 if self.voGroup == '': msg += "(i.e. no VO group) "
                 msg += "as specified in the command line."
                 self.logger.info(msg % self.voGroup)
-            if getattr(self.configuration.Data, 'publication', None) and \
-               not getattr(self.configuration.General, 'transferOutput', self.requestmapper['saveoutput']['default']):
-                msg = "Crab configuration problem: Data.publication is ON, but General.transferOutput is OFF.\n"
-                msg += "Publication can not be performed if the output files are not transferred to a permanent storage."
-                self.logger.info(msg)
-                raise ConfigurationException("Incompatible configuration options Data.publication and General.transferOutput")
 
         ##if we get an input task we load the cache and set the url from it
 

--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -63,14 +63,15 @@ class Analysis(BasicJobType):
         cmsswCfg = CMSSWConfig(config=self.config, logger=self.logger,
                                userConfig=self.config.JobType.psetName)
 
-        # Interogate CMSSW config and user config for output file names, for now no use for edmFiles or TFiles here.
-        analysisFiles, edmFiles = cmsswCfg.outputFiles()
-        self.logger.debug("TFiles %s and EDM Files %s will be collected" % (analysisFiles, edmFiles))
-        configArguments['tfileoutfiles'] = analysisFiles
-        configArguments['edmoutfiles'] = edmFiles
+        ## Interogate CMSSW config and user config for output file names. For now no use for EDM files or TFiles here.
+        edmfiles, tfiles = cmsswCfg.outputFiles()
+        self.logger.debug("The following EDM output files will be collected: %s" % edmfiles)
+        self.logger.debug("The following TFile output files will be collected: %s" % tfiles)
+        configArguments['edmoutfiles'] = edmfiles
+        configArguments['tfileoutfiles'] = tfiles
 
         outputFiles = getattr(self.config.JobType, 'outputFiles', [])
-        self.logger.debug("User files %s will be collected" % outputFiles)
+        self.logger.debug("The following user output files will be collected: %s" % outputFiles)
         configArguments['addoutputfiles'].extend(outputFiles)
 
         # Write out CMSSW config

--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -77,23 +77,13 @@ class CMSSWConfig(object):
 
     def outputFiles(self):
         """
-        Returns a tuple of lists of output files. First element is TFileService files,
-        second is PoolOutput files
+        Returns a tuple of lists of output files. First element is PoolOutput files,
+        second is TFileService files.
         """
 
-        tFiles = []
-        poolFiles = []
-
-        # Find TFileService
-        if self.fullConfig.process.services.has_key('TFileService'):
-            tFileService = self.fullConfig.process.services['TFileService']
-            if "fileName" in tFileService.parameterNames_():
-                tFiles.append(getattr(tFileService, 'fileName', None).value())
-
-        # Find files written by output modules
-        poolFiles = []
+        ## Find files written by output modules.
+        edmfiles = []
         outputModuleNames = self.fullConfig.process.outputModules_().keys()
-
         for outputModName in outputModuleNames:
             outputModule = getattr(self.fullConfig.process, outputModName)
             if not outputModule:
@@ -101,9 +91,8 @@ class CMSSWConfig(object):
             fileName = getattr(outputModule, 'fileName')
             if not fileName:
                 continue
-            poolFiles.append(fileName.value())
-
-        # If there are multiple output files, make sure they have filterNames set
+            edmfiles.append(fileName.value())
+        ## If there are multiple output modules, make sure they have dataset.filterName set.
         if len(outputModuleNames) > 1:
             for outputModName in outputModuleNames:
                 try:
@@ -114,4 +103,11 @@ class CMSSWConfig(object):
                     raise RuntimeError('Your output module %s does not have a "dataset" PSet ' % outputModName +
                                        'or the PSet does not have a "filterName" member.')
 
-        return tFiles, poolFiles
+        ## Find files written by TFileService.
+        tfiles = []
+        if self.fullConfig.process.services.has_key('TFileService'):
+            tFileService = self.fullConfig.process.services['TFileService']
+            if "fileName" in tFileService.parameterNames_():
+                tfiles.append(getattr(tFileService, 'fileName').value())
+
+        return edmfiles, tfiles

--- a/test/python/CRABClient_t/JobType_t/CMSSWConfig_t.py
+++ b/test/python/CRABClient_t/JobType_t/CMSSWConfig_t.py
@@ -136,8 +136,8 @@ class CMSSWConfigTest(unittest.TestCase):
         """
 
         cmsConfig = CMSSWConfig(config=None, userConfig='unittest_cfg.py', logger=self.logger)
-        self.assertEqual(cmsConfig.outputFiles()[0], ['histograms.root'])
-        self.assertEqual(cmsConfig.outputFiles()[1], ['output.root', 'output2.root'])
+        self.assertEqual(cmsConfig.outputFiles()[0], ['output.root', 'output2.root'])
+        self.assertEqual(cmsConfig.outputFiles()[1], ['histograms.root'])
 
 
     def testUpload(self):


### PR DESCRIPTION
The warning message is printed only if the CMSSW pset produces TFiles or if the user specified additional output files to be collected.
I also moved a check that we had about the publication and transferOutput flags not being respectively True and False, inside the validateConfig() function of submit (it was inside the **init**() of SubCommand).
I also moved a check that we had about the storage site being specified if transferOutput or saveLogs flags are True, inside the validateConfig() function of submit (it was inside the **call**() of submit).
The rest of the changes in the commit are just to make the code more readable (IMO). Sorry for making such changes. Tell me if you don't want me to do this.
This pull request is for issue https://github.com/dmwm/CRABServer/issues/4358
