### PR TITLE
alpha release of crabclient library api

### DIFF
--- a/src/python/CRABClient/ClientAPI/ClientLogger.py
+++ b/src/python/CRABClient/ClientAPI/ClientLogger.py
@@ -1,0 +1,110 @@
+import logging
+import sys
+
+
+class ClientLogger():
+
+    def chkinstance(self , cmdobj):
+
+        if hasattr(cmdobj, 'logger'):
+            return cmdobj.logger
+        else:
+            raise Exception('Object has no logger attribute')
+
+    def add(self , cmdobj,  logname = '', loglevel = 'info', logdestination = None ):
+
+        loginstace = self.chkinstance(cmdobj)
+
+        if not hasattr(loginstace , 'logdic'):
+            loginstace.logdic= {}
+
+        acceptedlevel = ['info' , 'quiet' , 'debug']
+
+        if logname is '' or logname in loginstace.logdic:
+            raise Exception('logname value is None or already being used')
+        elif loglevel not in acceptedlevel:
+            raise Exception('Only this level is accepted : %s' %acceptedlevel)
+
+        if logdestination is None:
+            d = {'handler': logging.StreamHandler(sys.stdout) , 'destination': 'sys.stdout' , 'level' : loglevel}
+            loginstace.logdic[logname] = d
+        else:
+            try:
+                d = {'handler' : logging.FileHandler(logdestination) , 'destination' : logdestination , 'level' : loglevel}
+                loginstace.logdic[logname] = d
+            except IOError:
+                raise IOError('Failed to add %s as file log' % logdestination)
+
+        #setting the format
+        if loglevel is 'debug':
+            formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s %(message)s")
+        else:
+            formatter = logging.Formatter("%(message)s")
+
+        loginstace.logdic[logname]['handler'].setFormatter(formatter)
+
+
+        if loglevel is 'info':
+            loginstace.logdic[logname]['handler'].setLevel(logging.INFO)
+        elif loglevel is 'quiet':
+            loginstace.logdic[logname]['handler'].setLevel(logging.WARNING)
+        elif loglevel is 'debug':
+            loginstace.logdic[logname]['handler'].setLevel(logging.DEBUG)
+
+        loginstace.addHandler(loginstace.logdic[logname]['handler'])
+        loginstace.info('Logger %s has been add' %logname)
+
+    def remove(self, cmdobj, logname = ''):
+
+        loginstace = self.chkinstance(cmdobj)
+        if not hasattr(loginstace,'logdic'):
+            raise Exception('Logdic not found')
+
+        if len(loginstace.logdic) is 0:
+            print ('Error : Log list is zero')
+
+        elif logname in loginstace.logdic:
+
+            loginstace.removeHandler(loginstace.logdic[logname]['handler'])
+            del loginstace.logdic[logname]
+            print ('Logger %s has been removed' % logname)
+
+        elif logname is 'all':
+            loginstace.handlers = []
+            loginstace.logdic = {}
+            print 'All logger has been romoved'
+
+        else:
+            raise Exception('Failed to find %s in the loglist' % logname)
+
+    def info(self, cmdobj,  logname = ''):
+
+        loginstace = self.chkinstance(cmdobj)
+
+        if not hasattr(loginstace,'logdic'):
+            raise Exception('Logdic not found')
+
+        print'{0:20s} {1:20s} {2:20s}'.format('Name','Destination','Level')
+        def printlogdata(logname):
+            print ('{0:20s} {1:20s} {2:20s}'.format(logname, loginstace.logdic[logname]['destination'],loginstace.logdic[logname]['level']))
+
+        if logname != '' and logname in loginstace.logdic:
+            printlogdata(loginstace.logdic[logname])
+        else:
+            for loghandler in loginstace.logdic:
+                printlogdata(loghandler)
+
+    def default(self, cmdobj):
+
+        print 'Restoring logging system to default'
+
+        if not hasattr(cmdobj, 'logger'):
+            cmdobj.logger = logging.getLogger()
+
+        self.remove(cmdobj, 'all')
+        self.add(cmdobj, logname = 'default')
+        self.add(cmdobj, logname = 'default_logfile' , loglevel = 'debug' , logdestination = 'crab.log')
+
+        print 'Logger has been restored to default'
+
+

--- a/src/python/CRABClient/ClientAPI/Command.py
+++ b/src/python/CRABClient/ClientAPI/Command.py
@@ -1,0 +1,93 @@
+import logging
+import sys
+import pycurl
+from httplib import HTTPException
+from CRABClient.ClientMapping import mapping
+from CRABClient.ClientAPI.ClientLogger import ClientLogger
+from WMCore.Configuration import Configuration
+
+class Command():
+
+    def __call__(self, command = None, *args, **kwargs):
+        if command == None:
+            raise Exception('No command is given')
+        if len(args) == 0 and len(kwargs) == 0 :
+            raise Exception('Argumnet must be given')
+
+        #if the user provide a class config rather than a config python file
+        if 'config' in kwargs.keys() and isinstance(kwargs['config'], Configuration):
+            cmdarg = ['--config' , kwargs['config']]
+            if len(args) != 0:
+                cmdarg.extend(args)
+        else:
+            #all kwargs argument have to be transformed into a list, first white space is removed, then '--' and '=' is added to kwargs.keys and kwargs value respectively. Then joined
+            cmdarg = [''.join(('--'+str(arg)+'='+str(kwargs[arg])).split()) for arg in kwargs]
+            cmdarg.extend(args)
+
+        try:
+            mod = __import__('CRABClient.Commands.%s' % command, fromlist=command)
+        except ImportError:
+            raise Exception('Wrong crab command give, command give: %s' % command)
+        try:
+            cmdobj = getattr(mod, command)(self.logger , cmdarg)
+            cmdobj.fromapi = True
+
+            return cmdobj()
+
+        except HTTPException, he:
+            self.logger.info("Error contacting the server.")
+            if he.status==503 and he.result.find("CMSWEB Error: Service unavailable")!=-1:
+                self.logger.info("It seems the CMSWEB frontend is not responding. Please check: https://twiki.cern.ch/twiki/bin/viewauth/CMS/ScheduledInterventions")
+            if he.headers.has_key('X-Error-Detail'):
+                self.logger.info('Server answered with: %s' % he.headers['X-Error-Detail'])
+            if he.headers.has_key('X-Error-Info'):
+                reason = he.headers['X-Error-Info']
+                for parname in mapping['submit']['map']:
+                    for tmpmsg in ['\''+parname+'\' parameter','Parameter \''+parname+'\'']:
+                        if tmpmsg in reason and mapping['submit']['map'][parname]['config']:
+                            reason = reason.replace(tmpmsg,tmpmsg.replace(parname,mapping['submit']['map'][parname]['config']))
+                            break
+                    else:
+                        continue
+                    break
+                self.logger.info('Reason is: %s' % reason)
+            #The following goes to the logfile.
+            errmsg = "ERROR: %s (%s): " % (he.reason, he.status)
+            ## answer can be a json or not
+            try:
+                errmsg += " '%s'" % he.result
+            except ValueError:
+                pass
+            self.logger.info(errmsg)
+            self.logger.info('Command failed with URI: %s' % he.url)
+            self.logger.info('     Input data: %s' % he.req_data)
+            self.logger.info('     Request headers: %s' % he.headers)
+            logging.getLogger('CRAB3:traceback').exception('Caught exception')
+
+            raise HTTPException , he
+
+        except pycurl.error, pe:
+            self.logger.error(pe)
+            logging.getLogger('CRAB3:traceback').exception('Caught exception')
+            if pe[1].find('(DNS server returned answer with no data)'):
+                self.logger.info("It seems the CMSWEB frontend is not responding. Please check: https://twiki.cern.ch/twiki/bin/viewauth/CMS/ScheduledInterventions")
+
+            raise Exception
+
+        except SystemExit , he:
+            self.logger.info(he)
+
+            raise Exception
+
+    def __init__(self, loglevel = 'info'):
+
+        #setting the enviroment log level to debug
+
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.DEBUG)
+
+        log = ClientLogger()
+        log.add(self, logname = 'default')
+        log.add(self, logname = 'default_logfile' , loglevel = 'debug' , logdestination = 'crab.log')
+
+

--- a/src/python/CRABClient/ClientAPI/__init__.py
+++ b/src/python/CRABClient/ClientAPI/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""
+CRAB Client library modules
+"""
+
+

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -32,6 +32,13 @@ class ConfigCommand:
         Load the configuration file
         """
 
+        if isinstance(configname, Configuration):
+            self.configuration = configname
+            valid, configmsg = self.validateConfig()
+            if not valid:
+                raise ConfigurationException(configmsg)
+            return
+
         if not os.path.isfile(configname):
             raise ConfigurationException("Configuration file '%s' not found" % configname)
         self.logger.info('Will use configuration file %s' % configname)

--- a/src/python/CRABClient/Commands/checkHNname.py
+++ b/src/python/CRABClient/Commands/checkHNname.py
@@ -24,9 +24,9 @@ class checkHNname(SubCommand):
     def __call__(self):
 
         if self.options.standalone:
-            self.standaloneCheck()
+            return self.standaloneCheck()
         else:
-            self.crabCheck()
+            return self.crabCheck()
 
 
     def terminate(self, exitcode):
@@ -51,20 +51,24 @@ class checkHNname(SubCommand):
         cmd += " | grep -A1 login"
         cmd += " | tail -1"
         status, hn_username = commands.getstatusoutput(cmd)
-        hn_username = string.strip(hn_username) 
+        hn_username = string.strip(hn_username)
         hn_username = hn_username.replace('"','')
         self.logger.info('Your HN username is: %s' % hn_username)
         self.logger.info('Finished')
 
+        return {'DN' : dn , 'HNusername' : hn_username}
 
     def crabCheck(self):
-    
+
         ## Do we need to add something here?
- 
+
         self.logger.info('Starting check in CRAB-like mode...')
-        self.logger.info('Your DN is: %s' % self.getDN())
+        dn = self.getDN()
+        self.logger.info('Your DN is: %s' % dn)
+        hn_username = None
         try:
-            self.logger.info('Your HN username is: %s\n' % self.getHNUsernameFromSiteDB())
+            hn_username = self.getHNUsernameFromSiteDB()
+            self.logger.info('Your HN username is: %s\n' % hn_username)
         except:
             self.logger.info('WARNING native crab_utils failed!')
             dn = urllib.urlencode({'dn': self.getDN()})
@@ -77,6 +81,7 @@ class checkHNname(SubCommand):
                 self.logger.info('problems with crab_utils')
         self.logger.info('Finished')
 
+        return {'DN' : dn , 'HNusername' : hn_username}
 
     def getDN(self):
         """

--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -44,16 +44,21 @@ class checkwrite(SubCommand):
                 else:
                     self.logger.info('Successfully deleted file %s from site %s' % (pfn, self.options.sitename))
                 self.logger.info('%sSuccess%s: Able to write on site %s' % (colors.GREEN, colors.NORMAL, self.options.sitename))
+
+                returndict = {'status' : 'SUCCESS'}
+
                 stop = True
             else:
                 if 'Permission denied' in cperr or 'mkdir: cannot create directory' in cperr:
                     self.logger.info('%sError%s: Unable to write on site %s' % (colors.RED, colors.NORMAL, self.options.sitename))
                     self.logger.info('       You may want to contact the site administrators sending them the \'crab checkwrite\' output as printed above')
+                    returndict = {'status' : 'FAILED'}
                     stop = True
                 elif 'timeout' in cpout or 'timeout' in cperr:
                     self.logger.info('Connection time out')
                     self.logger.info('Unable to check write permission on site %s' % self.options.sitename)
                     self.logger.info('Please try again later or contact the site administrators sending them the \'crab checkwrite\' output as printed above')
+                    returndict = {'status' : 'FAILED' }
                     stop = True
                 elif 'exist' in cpout or 'exist' in cperr and retry == 0:
                     self.logger.info('Error copying file %s to site %s; it may be that file already exists' % (self.filename, self.options.sitename))
@@ -69,10 +74,12 @@ class checkwrite(SubCommand):
                 else:
                     self.logger.info('Unable to check write permission on site %s' % self.options.sitename)
                     self.logger.info('Please try again later or contact the site administrators sending them the \'crab checkwrite\' output as printed above')
+                    returndict = {'status' : 'FAILED'}
                     stop = True
             if stop or use_new_file:
                 self.removeFile()
         self.logger.info('%sNOTE%s: you cannot write to a site if you did not ask permission' % (colors.BOLD, colors.NORMAL))
+        return returndict
 
 
     def createFile(self):

--- a/src/python/CRABClient/Commands/getlog.py
+++ b/src/python/CRABClient/Commands/getlog.py
@@ -16,7 +16,7 @@ The task is identified by -t/--task option
     visible = True #overwrite getcommand
 
     def __call__(self):
-        getcommand.__call__(self, subresource = 'logs')
+        return getcommand.__call__(self, subresource = 'logs')
 
 
     def setOptions(self):

--- a/src/python/CRABClient/Commands/getoutput.py
+++ b/src/python/CRABClient/Commands/getoutput.py
@@ -13,7 +13,7 @@ class getoutput(getcommand):
     visible = True #overwrite getcommand
 
     def __call__(self):
-        getcommand.__call__(self, subresource = 'data')
+        return getcommand.__call__(self, subresource = 'data')
 
     def setOptions(self):
         """

--- a/src/python/CRABClient/Commands/kill.py
+++ b/src/python/CRABClient/Commands/kill.py
@@ -27,7 +27,12 @@ class kill(SubCommand):
 
         self.logger.info("Kill request successfully sent")
         if dictresult['result'][0]['result'] != 'ok':
+            resultdict = {'status' : 'FAILED'}
             self.logger.info(dictresult['result'][0]['result'])
+        else:
+            resultdict = {'status' : 'SUCCESS'}
+
+        return resultdict
 
 
     def setOptions(self):

--- a/src/python/CRABClient/Commands/purge.py
+++ b/src/python/CRABClient/Commands/purge.py
@@ -46,7 +46,9 @@ class purge(SubCommand):
             raise ConfigurationException(msg)
 
         #getting the cache url
-
+        cacheresult = {}
+        scheddresult = {}
+        gsisshdict = {}
         if not self.options.scheddonly:
             baseurl=self.getUrl(self.instance, resource='info')
             cacheurl=server_info('backendurls', self.serverurl, self.proxyfilename, baseurl)
@@ -67,22 +69,24 @@ class purge(SubCommand):
 
             if ufcresult == '' :
                 self.logger.info('%sSuccess%s: Successfully remove file from cache' % (colors.GREEN, colors.NORMAL))
+                cacheresult = 'SUCCESS'
             else:
                 self.logger.info('%sError%s: Failed to remove the file from cache' % (colors.RED, colors.NORMAL))
+                cacheresult = 'FAILED'
 
         if not self.options.cacheonly:
             self.logger.info('Getting the schedd address')
             baseurl=self.getUrl(self.instance, resource='info')
             try:
-                sceddaddress = server_info('scheddaddress', self.serverurl, self.proxyfilename, baseurl, workflow = self.cachedinfo['RequestName'] )
+                scheddaddress = server_info('scheddaddress', self.serverurl, self.proxyfilename, baseurl, workflow = self.cachedinfo['RequestName'] )
             except HTTPException, he:
                 self.logger.info('%sError%s: Failed to get the schedd address' % (colors.RED, colors.NORMAL))
                 raise HTTPException,he
             self.logger.debug('%sSuccess%s: Successfully getting schedd address' % (colors.GREEN, colors.NORMAL))
-            self.logger.debug('Schedd address: %s' % sceddaddress)
+            self.logger.debug('Schedd address: %s' % scheddaddress)
             self.logger.info('Attempting to clean user file schedd')
 
-            gssishrm = 'gsissh -o ConnectTimeout=60 -o PasswordAuthentication=no ' + sceddaddress + ' rm -rf ' + self.cachedinfo['RequestName']
+            gssishrm = 'gsissh -o ConnectTimeout=60 -o PasswordAuthentication=no ' + scheddaddress + ' rm -rf ' + self.cachedinfo['RequestName']
             self.logger.debug('gsissh command: %s' % gssishrm)
 
             delprocess=subprocess.Popen(gssishrm, stdout= subprocess.PIPE, stderr= subprocess.PIPE, shell=True)
@@ -91,9 +95,16 @@ class purge(SubCommand):
 
             if exitcode == 0 :
                 self.logger.info('%sSuccess%s: Successfully remove task from scehdd' % (colors.GREEN, colors.NORMAL))
+                scheddresult = 'SUCCESS'
+                gsisshdict = {}
             else :
                 self.logger.info('%sError%s: Failed to remove task from schedd' % (colors.RED, colors.NORMAL))
+                scheddaddress = 'FAILED'
                 self.logger.debug('gsissh stdout: %s\ngsissh stderr: %s\ngsissh exitcode: %s' % (stdout,stderr,exitcode))
+                gsisshdict = {'stdout' : stdout, 'stderr' : stderr , 'exitcode' : exitcode}
+
+            return {'cacheresult' : cacheresult , 'scheddresult' : scheddresult , 'gsiresult' : gsisshdict}
+
 
     def setOptions(self):
         """

--- a/src/python/CRABClient/Commands/remake.py
+++ b/src/python/CRABClient/Commands/remake.py
@@ -15,7 +15,7 @@ class remake(SubCommand):
 
     def __call__(self):
 
-        self.remakecache(''.join(self.options.cmptask.split()))
+        return self.remakecache(''.join(self.options.cmptask.split()))
 
     def remakecache(self,taskname):
         #checking and making the request area if does not exist
@@ -37,8 +37,10 @@ class remake(SubCommand):
                 self.logger.info('%sWarning%s: Failed to make a requestare' % (colors.RED, colors.NORMAL))
 
             self.logger.info('Remaking the .requestcache for %s' % taskname)
-            pickle.dump({'voGroup': '', 'Server': self.serverurl , 'instance': self.instance,'RequestName': taskname, 'voRole': '', 'Port': ''}, open(cachepath , 'w'))
+            jsonfile = {'voGroup': '', 'Server': self.serverurl , 'instance': self.instance,'RequestName': taskname, 'voRole': '', 'Port': ''}, open(cachepath , 'w')
+            pickle.dump(jsonfile)
             self.logger.info('%sSuccess%s: Finish making %s ' % (colors.GREEN, colors.NORMAL, cachepath))
+            return jsonfile
 
     def setOptions(self):
         """

--- a/src/python/CRABClient/Commands/remote_copy.py
+++ b/src/python/CRABClient/Commands/remote_copy.py
@@ -150,6 +150,8 @@ class remote_copy(SubCommand):
             self.logger.info("%sSuccess%s: All files successfully retrieve " % (colors.GREEN,colors.NORMAL))
             globalExitcode=0
 
+        return successfiles , failedfiles
+
     def startchildproc(self, childprocess, nsubprocess, successfiles, failedfiles):
         """
         starting sub process and creating the queue

--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -34,24 +34,29 @@ class report(SubCommand):
         # check if we got the desired results
         if not self.usedbs and not dictresult['result'][0]['runsAndLumis']:
             self.logger.info('%sError%s: Fail in getting the information we need from the CRAB server. Only job that in FINISH state and the ouput has been transfered can be use' % (colors.RED,colors.NORMAL))
-            return dictresult
+
+            return {'result' : {'status' : 'ERROR' , 'result' : dictresult}}
+
         elif self.usedbs and not dictresult['result'][0]['dbsInLumilist'] and not dictresult['result'][0]['dbsOutLumilist']:
             self.logger.info('%sError%s: Fail in getting the information we need from DBS. Please check if the output (or input) dataset are not empty and the jobs is FINISH state and the publication'+\
                              ' has been performed' % (colors.RED, colors.NORMAL))
-            return dictresult
+
+            return {'result' : {'status' : 'ERROR' , 'result' : dictresult}}
 
         #get the runlumi per each job. runsAndLumis contains the filematadata info per job
         runlumiLists = map(lambda x: literal_eval(x['runlumi']), dictresult['result'][0]['runsAndLumis'].values())
+
         if not self.usedbs:
             analyzed, diff, doublelumis = BasicJobType.mergeLumis(runlumiLists, dictresult['result'][0]['lumiMask'])
             numFiles = len(reduce(set().union, map(lambda x: literal_eval(x['parents']), dictresult['result'][0]['runsAndLumis'].values())))
             self.logger.info("%d files have been read" % numFiles)
             self.logger.info("%d events have been read" % sum(map(lambda x: x['events'], dictresult['result'][0]['runsAndLumis'].values())))
+
         else:
             analyzed, diff, doublelumis = BasicJobType.subtractLumis(dictresult['result'][0]['dbsInLumilist'], dictresult['result'][0]['dbsOutLumilist'])
             self.logger.info("%d files have been read" % dictresult['result'][0]['dbsNumFiles'])
             self.logger.info("%d events have been read" % dictresult['result'][0]['dbsNumEvents'])
-
+        returndict = {}
         if self.outdir:
             if not os.path.exists(self.outdir):
                 self.logger.info('Creating directory: %s'  % self.outdir)
@@ -64,16 +69,21 @@ class report(SubCommand):
                 json.dump(analyzed, os.path.join(jsonFile))
                 jsonFile.write("\n")
                 self.logger.info("Analyzed lumi written to %s/lumiSummary.json" % jsonFileDir)
+                returndict['analyzed'] = analyzed
         if diff:
             with open(os.path.join(jsonFileDir, 'missingLumiSummary.json'), 'w') as jsonFile:
                 json.dump(diff, jsonFile)
                 jsonFile.write("\n")
                 self.logger.info("%sWarning%s: Not Analyzed lumi written to %s/missingLumiSummary.json" % (colors.RED, colors.NORMAL, jsonFileDir))
+                returndict['missingLumi']= diff
         if doublelumis:
             with open(os.path.join(jsonFileDir, 'double.json'), 'w') as jsonFile:
                 json.dump(doublelumis, jsonFile)
                 jsonFile.write("\n")
                 self.logger.info("%sWarning%s: Double lumis written to %s/double.json" % (colors.RED, colors.NORMAL, jsonFileDir))
+                returndict['doubleLumis'] = doublelumis
+
+        return {'result' : returndict , 'rawdict' : dictresult['result'][0]}
 
     def setOptions(self):
         """

--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -35,6 +35,11 @@ class resubmit(SubCommand):
         self.logger.info("Resubmit request successfully sent")
         if dictresult['result'][0]['result'] != 'ok':
             self.logger.info(dictresult['result'][0]['result'])
+            returndict = {'status' : 'FAILED'}
+        else:
+            returndict = {'status' : 'SUCCESS'}
+
+        return returndict
 
     def setOptions(self):
         """

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -85,6 +85,8 @@ class status(SubCommand):
             if self.json:
                self.logger.info(dictresult['jobs'])
 
+        return {'result' : dictresult}
+
     def printShort(self, dictresult, username):
 
         self.logger.debug(dictresult) #should be something like {u'result': [[123, u'ciao'], [456, u'ciao']]}

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -16,6 +16,8 @@ from CRABClient.client_exceptions import MissingOptionException, ConfigurationEx
 from CRABClient.client_utilities import getJobTypes, createCache, addPlugin, server_info, colors
 from CRABClient import __version__
 
+from WMCore.Configuration import Configuration
+
 DBSURLS = {'reader': {'global': 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader',
                       'phys01': 'https://cmsweb.cern.ch/dbs/prod/phys01/DBSReader',
                       'phys02': 'https://cmsweb.cern.ch/dbs/prod/phys02/DBSReader',
@@ -161,7 +163,7 @@ class submit(SubCommand):
         if self.options.wait:
             self.checkStatusLoop(server,uniquerequestname)
 
-        return uniquerequestname
+        return {'requestname' : self.requestname , 'uniquerequestname' : uniquerequestname }
 
 
     def setOptions(self):
@@ -184,21 +186,24 @@ class submit(SubCommand):
                                 default=False )
 
 
+
     def validateOptions(self):
         """
-        After doing the general options validation from the parent SubCommand class, 
+        After doing the general options validation from the parent SubCommand class,
         do the validation of options that are specific to the submit command.
         """
+
         ## First call validateOptions() from the SubCommand class.
         SubCommand.validateOptions(self)
         ## If no configuration file was passed as an option, try to extract it from the arguments.
-        ## Assume that the arguments can only be: 
-        ##     1) the configuration file name, and 
+        ## Assume that the arguments can only be:
+        ##     1) the configuration file name, and
         ##     2) parameters to override in the configuration file.
-        ## The last ones should all contain an '=' sign, so these are not candidates to be the 
+        ## The last ones should all contain an '=' sign, so these are not candidates to be the
         ## configuration file argument. Also, the configuration file name should end with '.py'.
         ## If can not find a configuration file candidate, use the default 'crabConfig.py'.
         ## If find more than one candidate, raise ConfigurationException.
+
         if self.options.config is None:
             use_default = True
             if len(self.args):
@@ -324,7 +329,7 @@ class submit(SubCommand):
 
         self.logger.info("Waiting for task to be processed")
 
-        maxwaittime= 900 #in second, changed to 15 minute max wait time, the original 1 hour is too long 
+        maxwaittime= 900 #in second, changed to 15 minute max wait time, the original 1 hour is too long
         starttime=currenttime=time.time()
         endtime=currenttime+maxwaittime
 

--- a/src/python/CRABClient/Commands/uploadlog.py
+++ b/src/python/CRABClient/Commands/uploadlog.py
@@ -13,7 +13,6 @@ class uploadlog(SubCommand):
     shortnames = ['uplog']
 
     def __call__(self):
-
         self.logger.debug("uploadlog started")
         #veryfing the log file exist
         if hasattr(self.options, 'logpath') and self.options.logpath != None:
@@ -40,6 +39,8 @@ class uploadlog(SubCommand):
         self.logger.info("%sSuccess%s: Finish uploading log file" % (colors.GREEN, colors.NORMAL))
         logfileurl = cacheurl + '/logfile?name='+str(logfilename)
         self.logger.info("Log file url: %s" %logfileurl)
+
+        return {'result' : {'status' : 'SUCCESS' , 'logurl' : logfileurl}}
 
     def setOptions(self):
         """


### PR DESCRIPTION
fix #4091 

Introducing the client library API. 

Example of command: 

from CRABClient.ClientAPI.Command import Command 

cmd = Command()
submitdict = cmd('submit', '--wait', config=<crabconfig.py string>)
statusdict = cmd('status', '--long', task=<task name string>)
checkwritedict = cmd('checkwrite', site='T2_CH_CERN')

each command will return a dict, must write an option that do not take variable before (--wait, --long, --summary, etc), option that take argument (--config, --task, --sort, --instance, etc). 

document draft: https://twiki.cern.ch/twiki/bin/viewauth/CMS/CRABClientLibraryAPI

please ignore the ClientLogger libraray for the moment 
