### PR TITLE
Allow EDM files and TFiles to be specified in the outputFiles flag.

### DIFF
--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -66,13 +66,12 @@ class Analysis(BasicJobType):
 
         ## Interogate CMSSW config and user config for output file names. For now no use for EDM files or TFiles here.
         edmfiles, tfiles = cmsswCfg.outputFiles()
+        outputFiles = [file for file in getattr(self.config.JobType, 'outputFiles', []) if file not in edmfiles+tfiles]
         self.logger.debug("The following EDM output files will be collected: %s" % edmfiles)
         self.logger.debug("The following TFile output files will be collected: %s" % tfiles)
+        self.logger.debug("The following user output files will be collected: %s" % outputFiles)
         configArguments['edmoutfiles'] = edmfiles
         configArguments['tfileoutfiles'] = tfiles
-
-        outputFiles = getattr(self.config.JobType, 'outputFiles', [])
-        self.logger.debug("The following user output files will be collected: %s" % outputFiles)
         configArguments['addoutputfiles'].extend(outputFiles)
 
         # Write out CMSSW config


### PR DESCRIPTION
The JobType.outputFiles parameter is used for the user to specify additional output files that should be collected on top of the EDM and TFileService output files. Currently, if the user by mistake specifies one EDM or TFileService output file in this parameter, the job will inject to CouchDB twice (same doc id, with different 'job_end_time' and 'last_update' values). This patch is to ignore EDM file names and TFileService file names specified in the JobType.outputFiles parameter.
