### PR TITLE
Use Analysis as default job type. And more. Fixes #4244, #4222 and #4156. 

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -26,7 +26,7 @@ from socket import error as SocketError
 from CRABClient import __version__ as client_version
 from CRABClient.client_utilities import getAvailCommands, logfilter
 from CRABClient.client_exceptions import ClientException
-from CRABClient.ClientMapping import mapping
+from CRABClient.ClientMapping import parameters_mapping
 
 
 class MyNullHandler(logging.Handler):
@@ -219,10 +219,10 @@ if __name__ == "__main__":
             client.logger.info('Server answered with: %s' % he.headers['X-Error-Detail'])
         if he.headers.has_key('X-Error-Info'):
             reason = he.headers['X-Error-Info']
-            for parname in mapping['submit']['map']:
+            for parname in parameters_mapping['on-server']:
                 for tmpmsg in ['\''+parname+'\' parameter','Parameter \''+parname+'\'']:
-                    if tmpmsg in reason and mapping['submit']['map'][parname]['config']:
-                        reason = reason.replace(tmpmsg,tmpmsg.replace(parname,mapping['submit']['map'][parname]['config']))
+                    if tmpmsg in reason and parameters_mapping['on-server'][parname]['config']:
+                        reason = reason.replace(tmpmsg,tmpmsg.replace(parname,parameters_mapping['on-server'][parname]['config']))
                         break
                 else:
                     continue

--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -3,59 +3,79 @@
 _ClientMapping_
 
 This allows to have an agnostic client.
-For each client command it is possible to define
-the path of the REST request, the map between
-the client configuration and the final request
-to send to the server. It includes type of the parameter
-to have the client doing a basic sanity check on
-the input data type.
+For each client command it is possible to define the path of the REST request, the map between
+the client configuration and the final request to send to the server. It includes type of the 
+parameter so that the client can do a basic sanity check on the input data type.
+For each server parameter, there can be more than one parameters in the CRAB configuration file.
+If that is the case then the meaning is that any of the parameters in the CRAB configuration
+file is used to set the same server parameter.
 """
 
-mapping = {
-    'submit' :  { 'map': {  "jobtype"           : {"default": "Analysis",       "config": None,                              "type": "StringType",  "required": True },
-                            "workflow"          : {"default": None,             "config": None,                              "type": "StringType",  "required": True },
-                            "savelogsflag"      : {"default": False,            "config": 'General.saveLogs',                "type": "BooleanType", "required": False},
-                            "asyncdest"         : {"default": None,             "config": 'Site.storageSite',                "type": "StringType",  "required": False},
-                            "saveoutput"        : {"default": True,             "config": 'General.transferOutput',          "type": "BooleanType", "required": False},
-                            "publishname"       : {"default": '',               "config": 'Data.publishDataName',            "type": "StringType",  "required": False},
-                            "dbsurl"            : {"default": 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader', "config": 'Data.dbsUrl',        "type": "StringType", "required": False},
-                            "publishdbsurl"     : {"default": 'https://cmsweb.cern.ch/dbs/prod/phys03/DBSWriter', "config": 'Data.publishDbsUrl', "type": "StringType", "required": False},
-                            "publication"       : {"default": True,             "config": 'Data.publication',                "type": "BooleanType", "required": False},
-                            "lfn"               : {"default": None,             "config": 'Data.outlfn',                     "type": "StringType",  "required": False},
-                            "sitewhitelist"     : {"default": None,             "config": 'Site.whitelist',                  "type": "ListType",    "required": False},
-                            "siteblacklist"     : {"default": None,             "config": 'Site.blacklist',                  "type": "ListType",    "required": False},
-                            "splitalgo"         : {"default": None,             "config": 'Data.splitting',                  "type": "StringType",  "required": True },
-                            "algoargs"          : {"default": None,             "config": 'Data.unitsPerJob',                "type": "IntType",     "required": True },
-                            "totalunits"        : {"default": 0,                "config": 'Data.totalUnits',                 "type": "IntType",     "required": False},
-                            "ignorelocality"    : {"default": False,            "config": 'Data.ignoreLocality',             "type": "BooleanType", "required": False},
-                            "addoutputfiles"    : {"default": [],               "config": 'JobType.outputFiles',             "type": "ListType",    "required": False},
-                            "vorole"            : {"default": None,             "config": 'User.voRole',                     "type": "StringType",  "required": False},
-                            "vogroup"           : {"default": None,             "config": 'User.voGroup',                    "type": "StringType",  "required": False},
-                            "maxjobruntime"     : {"default": None,             "config": "JobType.maxjobruntime",           "type": "IntType",     "required": False},
-                            "numcores"          : {"default": None,             "config": "JobType.numcores",                "type": "IntType",     "required": False},
-                            "maxmemory"         : {"default": None,             "config": "JobType.maxmemory",               "type": "IntType",     "required": False},
-                            "priority"          : {"default": None,             "config": "JobType.priority",                "type": "IntType",     "required": False},
-                            "faillimit"         : {"default": None,             "config": "General.failureLimit",            "type": "IntType",     "required": False},
-                            "nonprodsw"         : {"default": False,            "config": "JobType.allowNonProductionCMSSW", "type": "BooleanType", "required": False},
-                         },
-                  'other-config-params' : ["General.requestName", "General.workArea",
-                                           "JobType.pluginName", "JobType.externalPluginFile", "JobType.psetName",
-                                           "JobType.inputFiles", "JobType.pyCfgParams", "Data.primaryDataset",
-                                           "Data.inputDataset", "Data.lumiMask", "Data.runRange",
-                                           "General.instance", "Debug.oneEventMode", "Data.userInputFile"],
-                  'requiresTaskOption' : False,
-                },
-    'checkHNname'  : {'requiresTaskOption': False, 'requiresREST': False},
-    'checkwrite'   : {'requiresTaskOption': False, 'requiresREST': False},
-    'getlog'       : {'requiresTaskOption': True },
-    'getoutput'    : {'requiresTaskOption': True },
-    'kill'         : {'requiresTaskOption': True, 'allowUseOfTasknameFromCacheFile': False},
-    'purge'        : {'requiresTaskOption': True, 'allowUseOfTasknameFromCacheFile': False},
-    'remake'       : {'requiresTaskOption': False},
-    'remote_copy'  : {'requiresTaskOption': True, 'initializeProxy' : False},#proxy already inited by the calling command
-    'report'       : {'requiresTaskOption': True },
-    'request_type' : {'requiresTaskOption': True },
-    'resubmit'     : {'requiresTaskOption': True },
-    'status'       : {'requiresTaskOption': True },
-    'uploadlog'    : {'requiresTaskOption': False}
+parameters_mapping = {
+    'on-server': {'workflow'       : {'default': None,       'config': ['General.requestName'],             'type': 'StringType',  'required': False},
+                  'saveoutput'     : {'default': True,       'config': ['General.transferOutput'],          'type': 'BooleanType', 'required': False},
+                  'savelogsflag'   : {'default': False,      'config': ['General.saveLogs'],                'type': 'BooleanType', 'required': False},
+                  'faillimit'      : {'default': None,       'config': ['General.failureLimit'],            'type': 'IntType',     'required': False},
+                  'inputdata'      : {'default': None,       'config': ['Data.inputDataset',
+                                                                        'Data.primaryDataset'],             'type': 'StringType',  'required': False},
+                  'userfiles'      : {'default': None,       'config': ['Data.userInputFile'],              'type': 'StringType',  'required': False},
+                  'dbsurl'         : {'default': 'global',   'config': ['Data.dbsUrl'],                     'type': 'StringType',  'required': False},
+                  'ignorelocality' : {'default': False,      'config': ['Data.ignoreLocality'],             'type': 'BooleanType', 'required': False},
+                  'splitalgo'      : {'default': None,       'config': ['Data.splitting'],                  'type': 'StringType',  'required': True },
+                  'algoargs'       : {'default': None,       'config': ['Data.unitsPerJob'],                'type': 'IntType',     'required': True },
+                  'totalunits'     : {'default': 0,          'config': ['Data.totalUnits'],                 'type': 'IntType',     'required': False},
+                  'lfn'            : {'default': None,       'config': ['Data.outlfn'],                     'type': 'StringType',  'required': False},
+                  'publication'    : {'default': True,       'config': ['Data.publication'],                'type': 'BooleanType', 'required': False},
+                  'publishdbsurl'  : {'default': 'phys03',   'config': ['Data.publishDbsUrl'],              'type': 'StringType',  'required': False},
+                  'publishname'    : {'default': '',         'config': ['Data.publishDataName'],            'type': 'StringType',  'required': False},
+                  'jobtype'        : {'default': 'Analysis', 'config': ['JobType.pluginName',
+                                                                        'JobType.externalPluginFile'],      'type': 'StringType',  'required': False},
+                  'adduserfiles'   : {'default': [],         'config': ['JobType.inputFiles'],              'type': 'ListType',    'required': False},
+                  'addoutputfiles' : {'default': [],         'config': ['JobType.outputFiles'],             'type': 'ListType',    'required': False},
+                  'maxjobruntime'  : {'default': None,       'config': ['JobType.maxjobruntime'],           'type': 'IntType',     'required': False},
+                  'numcores'       : {'default': None,       'config': ['JobType.numcores'],                'type': 'IntType',     'required': False},
+                  'maxmemory'      : {'default': None,       'config': ['JobType.maxmemory'],               'type': 'IntType',     'required': False},
+                  'priority'       : {'default': None,       'config': ['JobType.priority'],                'type': 'IntType',     'required': False},
+                  'nonprodsw'      : {'default': False,      'config': ['JobType.allowNonProductionCMSSW'], 'type': 'BooleanType', 'required': False},
+                  'asyncdest'      : {'default': None,       'config': ['Site.storageSite'],                'type': 'StringType',  'required': False},
+                  'sitewhitelist'  : {'default': None,       'config': ['Site.whitelist'],                  'type': 'ListType',    'required': False},
+                  'siteblacklist'  : {'default': None,       'config': ['Site.blacklist'],                  'type': 'ListType',    'required': False},
+                  'vorole'         : {'default': None,       'config': ['User.voRole'],                     'type': 'StringType',  'required': False},
+                  'vogroup'        : {'default': None,       'config': ['User.voGroup'],                    'type': 'StringType',  'required': False},
+                  'oneEventMode'   : {'default': False,      'config': ['Debug.oneEventMode'],              'type': 'BooleanType', 'required': False},
+                 },
+    'other-config-params': ['General.workArea', 'General.instance', 'Data.lumiMask', 'Data.runRange', 'JobType.psetName', 'JobType.pyCfgParams']
 }
+
+
+commands_configuration = {
+    'submit'       : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': False, 'useCache': False},
+    'checkHNname'  : {'requiresREST': False, 'initializeProxy' : True,  'requiresTaskOption': False, 'useCache': False},
+    'checkwrite'   : {'requiresREST': False, 'initializeProxy' : True,  'requiresTaskOption': False, 'useCache': False},
+    'getlog'       : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': True },
+    'getoutput'    : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': True },
+    'kill'         : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': False},
+    'purge'        : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': False},
+    'remake'       : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': False, 'useCache': False},
+    'remote_copy'  : {'requiresREST': True,  'initializeProxy' : False, 'requiresTaskOption': True,  'useCache': True },
+    'report'       : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': True },
+    'request_type' : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': True },
+    'resubmit'     : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': True },
+    'status'       : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': True,  'useCache': True },
+    'uploadlog'    : {'requiresREST': True,  'initializeProxy' : True,  'requiresTaskOption': False, 'useCache': False}
+}
+
+
+def getParamServerName(param_config_name):
+    for param_server_name in parameters_mapping['on-server'].keys():
+        if param_config_name in parameters_mapping['on-server'][param_server_name]['config']:
+            return param_server_name
+    return None
+
+
+def getParamDefaultValue(param_config_name):
+    param_server_name = getParamServerName(param_config_name)
+    if param_server_name:
+        return parameters_mapping['on-server'][param_server_name]['default']
+    return None
+

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -7,7 +7,7 @@ from ast import literal_eval
 
 from CRABClient.client_utilities import loadCache, getWorkArea, server_info, createWorkArea
 from CRABClient.client_exceptions import ConfigurationException, MissingOptionException , EnvironmentException
-from CRABClient.ClientMapping import mapping
+from CRABClient.ClientMapping import parameters_mapping, commands_configuration
 from CRABClient.CredentialInteractions import CredentialInteractions
 from CRABClient.__init__ import __version__
 from CRABClient.client_utilities import colors
@@ -38,6 +38,7 @@ class ConfigCommand:
         try:
             self.logger.debug('Loading configuration')
             self.configuration = loadConfigurationFile(os.path.abspath(configname))
+            ## Overwrite configuration parameters passed as arguments in the command line. 
             if overrideargs:
                 for singlearg in overrideargs:
                     if singlearg == configname: continue
@@ -55,9 +56,9 @@ class ConfigCommand:
                         raise ConfigurationException('ERROR: Wrong command-line format.')
                     self.configuration.section_(parnames[0])
                     type = 'undefined'
-                    for k in self.requestmapper.keys():
-                        if self.requestmapper[k]['config'] == fullparname:
-                            type = self.requestmapper[k]['type']
+                    for k in parameters_mapping['on-server'].keys():
+                        if fullparname in parameters_mapping['on-server'][k]['config']:
+                            type = parameters_mapping['on-server'][k]['type']
                             break
                     if type in ['undefined','StringType']:
                         setattr(getattr(self.configuration, parnames[0]), parnames[1], literal_eval("\'%s\'" % parval))
@@ -109,28 +110,27 @@ class ConfigCommand:
         ## type specified in the configuration map.
         ## Check that, if a parameter is a required one and it has no default value,
         ## then it must be specified in the configuration file.
-        for param in self.requestmapper:
-            param_full_config_name = self.requestmapper[param].get('config')
-            if param_full_config_name is None:
-                continue
-            required_type_name = self.requestmapper[param].get('type', 'undefined')
-            try:
-                required_type = getattr(types, required_type_name)
-            except AttributeError, ex:
-                msg = "Invalid type '%s' specified in client configuration mapping for parameter '%s'." % (required_type_name, param)
-                return False, msg
-            attrs = param_full_config_name.split('.')
-            obj = self.configuration
-            while attrs and obj is not None:
-                obj = getattr(obj, attrs.pop(0), None)
-            if obj is not None:
-                if type(obj) != required_type:
-                    msg = "Invalid type %s for parameter '%s'. It is needed a %s." % (str(type(obj)), self.requestmapper[param]['config'], str(required_type))
+        for param in parameters_mapping['on-server']:
+            for param_full_config_name in parameters_mapping['on-server'][param]['config']:
+                required_type_name = parameters_mapping['on-server'][param].get('type', 'undefined')
+                try:
+                    required_type = getattr(types, required_type_name)
+                except AttributeError, ex:
+                    msg = "Invalid type %s specified in client configuration mapping for server parameter %s" % (required_type_name, param)
                     return False, msg
-            else:
-                if self.requestmapper[param].get('default') is None and self.requestmapper[param].get('required', False):
-                    msg = "Missing parameter '%s' in CRAB configuration file." % self.requestmapper[param]['config']
-                    return False, msg
+                attrs = param_full_config_name.split('.')
+                obj = self.configuration
+                while attrs and obj is not None:
+                    obj = getattr(obj, attrs.pop(0), None)
+                if obj is not None:
+                    if type(obj) != required_type:
+                        msg = "Crab configuration problem: Invalid type %s for parameter %s; it is needed a %s" \
+                              % (str(type(obj)), param_full_config_name, str(required_type))
+                        return False, msg
+                else:
+                    if parameters_mapping['on-server'][param].get('default') is None and parameters_mapping['on-server'][param].get('required', False):
+                        msg = "Crab configuration problem: Parameter %s is missing" % param_full_config_name
+                        return False, msg
 
         return True, "Valid configuration"
 
@@ -146,6 +146,7 @@ class SubCommand(ConfigCommand):
     #Default command name is the name of the command class, but it is also possible to set the name attribute in the subclass
     #if the command name does not correspond to the class name (getlog => get-log)
 
+
     def getUrl(self, instance='prod', resource='workflow'):
         """
         Retrieve the url depending on the resource we are accessing and the instance.
@@ -156,22 +157,6 @@ class SubCommand(ConfigCommand):
             return BASEURL + 'dev' + '/' + resource
         raise ConfigurationException('Error: only %s instances can be used.' %str(SERVICE_INSTANCES.keys()))
 
-    def loadMapping(self):
-        """
-        Load the command mapping from ClientMapping
-        """
-        #XXX Isn't it better to just copy the mapping with self.mapping = mapping[self.name] instead of copying each parameter?
-        self.requestmapper = None
-        if self.name in mapping:
-            if 'map' in mapping[self.name]:
-                self.requestmapper = mapping[self.name]['map']
-            self.requiresTaskOption = 'requiresTaskOption' in mapping[self.name] and mapping[self.name]['requiresTaskOption']
-            if self.requiresTaskOption:
-                self.allowUseOfTasknameFromCacheFile = True if 'allowUseOfTasknameFromCacheFile' not in mapping[self.name] else mapping[self.name]['allowUseOfTasknameFromCacheFile']
-            self.initializeProxy = True if 'initializeProxy' not in mapping[self.name] else mapping[self.name]['initializeProxy']
-            self.requiresREST = True if 'requiresREST' not in mapping[self.name] else mapping[self.name]['requiresREST']
-            if 'other-config-params' in mapping[self.name]:
-                self.otherConfigParams = mapping[self.name]['other-config-params']
 
     def __init__(self, logger, cmdargs = [], disable_interspersed_args = False):
         """
@@ -184,8 +169,7 @@ class SubCommand(ConfigCommand):
         self.logfile = self.logger.logfile
         self.logger.debug("Executing command: '%s'" % str(self.name))
         self.proxy = None
-        ##Get the mapping
-        self.loadMapping()
+        self.cmdconf = commands_configuration.get(self.name)
         self.crab3dic = self.getConfiDict()
 
         self.parser = OptionParser(description = self.__doc__, usage = self.usage, add_help_option = True)
@@ -193,17 +177,17 @@ class SubCommand(ConfigCommand):
         if disable_interspersed_args:
             self.parser.disable_interspersed_args()
         self.setSuperOptions()
-        ##Parse the command line parameters
+        ## Parse the command line parameters.
         (self.options, self.args) = self.parser.parse_args( cmdargs )
 
-        ##Validate the command line parameters before initing the proxy
+        ## Validate the command line parameters before initializing the proxy.
         self.validateOptions()
 
         self.voRole  = self.options.voRole  if self.options.voRole  is not None else ''
         self.voGroup = self.options.voGroup if self.options.voGroup is not None else ''
-        ##if we get an input configuration we load it
+        ## If we get an input configuration, we load it.
         if hasattr(self.options, 'config') and self.options.config is not None:
-            self.loadConfig( self.options.config, self.args )
+            self.loadConfig(self.options.config, self.args)
             self.requestarea, self.requestname, self.logfile = createWorkArea(self.logger,
                                                                               getattr(self.configuration.General, 'workArea', None),
                                                                               getattr(self.configuration.General, 'requestName', None))
@@ -222,14 +206,14 @@ class SubCommand(ConfigCommand):
                 msg += "as specified in the command line."
                 self.logger.info(msg % self.voGroup)
 
-        ##if we get an input task we load the cache and set the url from it
+        ## If we get an input task, we load the cache and set the url from it.
         if hasattr(self.options, 'task') and self.options.task:
             self.loadLocalCache()
 
-        ## if the server url isn't already set we check the args and then the config
-        if not hasattr(self, 'serverurl') and self.requiresREST:
+        ## If the server url isn't already set, we check the args and then the config.
+        if not hasattr(self, 'serverurl') and self.cmdconf['requiresREST']:
             self.instance, self.serverurl = self.serverInstance()
-        elif not self.requiresREST:
+        elif not self.cmdconf['requiresREST']:
             self.instance, self.serverurl = None, None
 
         self.updateCrab3()
@@ -237,18 +221,21 @@ class SubCommand(ConfigCommand):
         #logging user command and optin use for debuging purpose
         self.logger.debug('Command use: %s' % self.name)
         self.logger.debug('Options use: %s' % cmdargs)
-        if self.requiresREST:
+        if self.cmdconf['requiresREST']:
             self.checkversion(self.getUrl(self.instance, resource='info'))
             self.uri = self.getUrl(self.instance)
         self.logger.debug("Instance is %s" %(self.instance))
         self.logger.debug("Server base url is %s" %(self.serverurl))
-        if self.requiresREST:
+        if self.cmdconf['requiresREST']:
             self.logger.debug("Command url %s" %(self.uri))
 
+
     def serverInstance(self):
-        """Deriving the correct instance to use and the server url. Client is allow to propegate the instance name and coresponding url
-	   via crabconfig.py or crab option --intance. The variable pass via crab option will always be use over the varible
-	   in crabconfig.py. Instance name other than specify in the SERVICE_INSTANCE will be treated as a private instance."""
+        """
+        Deriving the correct instance to use and the server url. Client is allowed to propagate the instance name and corresponding url
+        via crabconfig.py or crab option --instance. The variable passed via crab option will always be used over the variable
+        in crabconfig.py. Instance name other than specify in the SERVICE_INSTANCE will be treated as a private instance.
+        """
         serverurl = None
 
         #Will be use to print available instances
@@ -277,21 +264,21 @@ class SubCommand(ConfigCommand):
 
         return instance, serverurl
 
+
     def checkversion(self, baseurl = None):
-
         compatibleversion = server_info('version', self.serverurl, self.proxyfilename, baseurl)
-
         if __version__ in compatibleversion:
             self.logger.debug("CRABClient version: %s Compatible"  % __version__)
         else:
             self.logger.info("%sWARNING%s: Incompatible CRABClient version \"%s\" " % (colors.RED, colors.NORMAL , __version__ ))
             self.logger.info("Server is saying that compatible versions are: %s"  % compatibleversion)
 
-    def handleProxy(self ):
-        """ Init the user proxy, and delegate it if necessary.
-        """
 
-        if not self.options.skipProxy and self.initializeProxy:
+    def handleProxy(self ):
+        """ 
+        Init the user proxy, and delegate it if necessary.
+        """
+        if not self.options.skipProxy and self.cmdconf['initializeProxy']:
             proxy = CredentialInteractions('', '', self.voRole, self.voGroup, self.logger, myproxyAccount=self.serverurl)
 
             self.proxy = proxy
@@ -299,7 +286,7 @@ class SubCommand(ConfigCommand):
             self.logger.debug("Checking credentials")
             _, self.proxyfilename = proxy.createNewVomsProxy( timeleftthreshold = 720 )
 
-            if self.requiresREST: #if the command does not contact the REST we can't delegate the proxy
+            if self.cmdconf['requiresREST']: #if the command does not contact the REST we can't delegate the proxy
                 proxy.myproxyAccount = self.serverurl
                 baseurl = self.getUrl(self.instance, resource='info')
                 #get the dn of the task workers from the server
@@ -316,8 +303,10 @@ class SubCommand(ConfigCommand):
             os.environ['X509_USER_PROXY'] = self.options.skipProxy
             self.logger.debug('Skipping proxy creation')
 
+
     def loadLocalCache(self, serverurl = None):
-        """ Loads the client cache and set up the server url
+        """ 
+        Loads the client cache and set up the server url
         """
         self.requestarea, self.requestname = getWorkArea( self.options.task )
         self.cachedinfo, self.logfile = loadCache(self.requestarea, self.logger)
@@ -327,18 +316,18 @@ class SubCommand(ConfigCommand):
         self.voRole = self.cachedinfo['voRole'] #if not self.options.voRole else self.options.voRole
         self.voGroup = self.cachedinfo['voGroup'] #if not self.options.voGroup else self.options.voGroup
 
+
     def getConfiDict(self):
 
-        crab3fdir=self.crabcachepath()
+        crab3fdir = self.crabcachepath()
         if not os.path.isfile(crab3fdir):
-            self.logger.debug("Could not find %s creating a new one" % crab3fdir)
+            self.logger.debug("Could not find %s file; creating a new one" % crab3fdir)
             crab3f = open(crab3fdir,'w')
             #creating a user dict, do add for future use
             configdict = { "taskname" : None }
             json.dump(configdict,crab3f)
             crab3f.close()
             return configdict
-
         else:
             try :
                 self.logger.debug("Found %s file" % crab3fdir)
@@ -346,10 +335,9 @@ class SubCommand(ConfigCommand):
                 configdict = json.load(crab3f)
                 crab3f.close()
             except ValueError:
-                self.logger.info('%sError%s: Error in reading json file\nTry to do "rm -rf ~/.crab3", and do the crab comment again'% (colors.RED, colors.NORMAL))
+                self.logger.info('%sError%s: Error in reading json file\nTry to do "rm -rf ~/.crab3", and run the crab command again'% (colors.RED, colors.NORMAL))
                 raise ConfigurationException
             return configdict
-
 
 
     def crabcachepath(self):
@@ -362,17 +350,20 @@ class SubCommand(ConfigCommand):
          else:
              return str(os.path.expanduser('~')) + '/.crab3'
 
+
     def updateCrab3(self):
-        if self.requiresTaskOption or hasattr(self,'requestname') and self.requestname != None:
+        if self.cmdconf['requiresTaskOption'] or hasattr(self,'requestname') and self.requestname != None:
             crab3fdir=self.crabcachepath()
             crab3f = open(crab3fdir, 'w')
             self.crab3dic['taskname'] = self.requestarea
             json.dump(self.crab3dic, crab3f)
             crab3f.close()
 
+
     def __call__(self):
         self.logger.info("This is a 'nothing to do' command")
         raise NotImplementedError
+
 
     def terminate(self, exitcode):
         #We do not want to print logfile for each command...
@@ -382,8 +373,10 @@ class SubCommand(ConfigCommand):
             else:
                 self.logger.info("Log file is %s" % os.path.abspath(self.logfile))
 
+
     def setOptions(self):
         raise NotImplementedError
+
 
     def setSuperOptions(self):
         try:
@@ -397,7 +390,7 @@ class SubCommand(ConfigCommand):
                                  help = "Skip Grid proxy creation and myproxy delegation.",
                                  metavar = "USERDN" )
 
-        if self.requiresTaskOption:
+        if self.cmdconf['requiresTaskOption']:
             self.parser.add_option( "-t", "--task",
                                      dest = "task",
                                      default = None,
@@ -410,12 +403,13 @@ class SubCommand(ConfigCommand):
         self.parser.add_option( "--voGroup",
                                 dest = "voGroup",
                                 default = None )
-        if self.requiresREST:
+        if self.cmdconf['requiresREST']:
 
             self.parser.add_option("--instance",
                                    dest = "instance",
                                    type = "string",
                                    help = "Running instance of CRAB service. Valid values are %s." %str(SERVICE_INSTANCES.keys()))
+
 
     def validateOptions(self):
         """
@@ -425,10 +419,10 @@ class SubCommand(ConfigCommand):
         Raise a ConfigurationException in case of error; don't do anything if ok.
         """
 
-        if self.requiresTaskOption and self.options.task is None:
+        if self.cmdconf['requiresTaskOption'] and self.options.task is None:
             if len(self.args) == 1 and self.args[0]:
                 self.options.task = self.args[0]
-            elif self.allowUseOfTasknameFromCacheFile and self.crab3dic["taskname"] != None:
-                self.options.task = self.crab3dic["taskname"]
+            elif self.cmdconf['useCache'] and self.crab3dic['taskname'] != None:
+                self.options.task = self.crab3dic['taskname']
             else:
                 raise MissingOptionException('ERROR: Task option is required.')

--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -84,7 +84,7 @@ class report(SubCommand):
         self.parser.add_option(  "--outputdir",
                                  dest = "outdir",
                                  default = None,
-                                 help = "Direcotory to write JSON summary to." )
+                                 help = "Directory to write JSON summary to." )
 
         self.parser.add_option( "--dbs",
                                  dest = "usedbs",

--- a/src/python/CRABClient/Commands/uploadlog.py
+++ b/src/python/CRABClient/Commands/uploadlog.py
@@ -42,6 +42,7 @@ class uploadlog(SubCommand):
         logfileurl = cacheurl + '/logfile?name='+str(logfilename)
         self.logger.info("Log file url: %s" %logfileurl)
 
+
     def setOptions(self):
         """
         __setOptions__
@@ -59,29 +60,27 @@ class uploadlog(SubCommand):
                                      default = None,
                                      help = "Same as -c/-continue" )
 
+
     def validateOptions(self):
         SubCommand.validateOptions(self)
 
         if hasattr(self.options, 'logpath') and self.options.logpath != None:
-            self.requiresTaskOption =  False
             if not path.isfile(self.options.logpath):
                 msg = '%sError%s: Could not find the log file in the path: %s' % (colors.RED,colors.NORMAL,self.options.logpath)
                 raise ConfigurationException(msg)
-
-        elif hasattr(self.options, 'task') and self.options.task == None:
-            self.requiresTaskOption = True
-            if len(self.args) == 1 and self.args[0]:
-                self.options.task = self.args[0]
-            #for the case of 'crab uploadlog', user is using the .crab3 file
-            if self.options.task == None and hasattr(self, 'crab3dic'):
-                if  self.crab3dic["taskname"] != None:
-                    self.options.task = self.crab3dic["taskname"]
-                    self.requiresTaskOption = True
-                else:
-                    msg = '%sError%s: Please use the task option -t or --logpath to specify which log to upload' % (colors.RED, colors.NORMAL)
-                    raise ConfigurationException(msg)
-        elif self.options.task != None:
-            self.requiresTaskOption = True
+        elif hasattr(self.options, 'task'):
+            self.cmdconf['requiresTaskOption'] = True
+            self.cmdconf['useCache'] = True
+            if self.options.task == None:
+                if len(self.args) == 1 and self.args[0]:
+                    self.options.task = self.args[0]
+                #for the case of 'crab uploadlog', user is using the .crab3 file
+                if self.options.task == None and hasattr(self, 'crab3dic'):
+                    if  self.crab3dic["taskname"] != None:
+                        self.options.task = self.crab3dic["taskname"]
+                    else:
+                        msg = '%sError%s: Please use the task option -t or --logpath to specify which log to upload' % (colors.RED, colors.NORMAL)
+                        raise ConfigurationException(msg)
         else:
             msg = '%sError%s: Please use the task option -t or --logpath to specify which log to upload' % (colors.RED, colors.NORMAL)
             raise ConfigurationException(msg)

--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -104,10 +104,8 @@ class Analysis(BasicJobType):
                 if not re.match("/%(primDS)s.*" % WMCore.Lexicon.lfnParts, primDS):
                     self.logger.warning("Invalid primary dataset name %s for private MC; publishing may fail" % primDS)
                 configArguments['inputdata'] = primDS
-            elif getattr(self.config.Data, 'inputDataset', None):
-                configArguments['inputdata'] = self.config.Data.inputDataset
             else:
-                configArguments['inputdata'] = "/CRAB_UserFiles"
+                configArguments['inputdata'] = getattr(self.config.Data, 'inputDataset', '/CRAB_UserFiles')
 
         lumi_mask_name = getattr(self.config.Data, 'lumiMask', None)
         lumi_list = None

--- a/src/python/CRABClient/client_utilities.py
+++ b/src/python/CRABClient/client_utilities.py
@@ -67,16 +67,14 @@ def getPlugins(namespace, plugins, skip):
 
     TODO: If we use WMCore more, replace with the WMFactory.
     """
-    packagemod = __import__( '%s.%s' % (namespace, plugins), \
-                                        globals(), locals(), plugins  )
+    packagemod = __import__('%s.%s' % (namespace, plugins), globals(), locals(), plugins)
     fullpath   = packagemod.__path__[0]
     modules = {}
     ## iterating on the modules contained in that package
     for el in list(pkgutil.iter_modules([fullpath])):
         if el[1] not in skip:
             ## import the package module
-            mod = __import__('%s.%s.%s' % (namespace, plugins, el[1]), \
-                                        globals(), locals(), el[1] )
+            mod = __import__('%s.%s.%s' % (namespace, plugins, el[1]), globals(), locals(), el[1])
             ## add to the module dictionary.
             ## N.B. Utilitiy modules like LumiMask do not have classes inside them
             modules[el[1]] = getattr(mod, el[1], None)
@@ -143,11 +141,9 @@ def getJobTypes(jobtypepath = 'CRABClient', jobtypename = 'JobType'):
 
 def getAvailCommands(subcmdpath = 'CRABClient', subcmdname = 'Commands'):
     """
-    _getJobTypes_
+    _getAvailCommands_
 
-    wrap the dynamic plug-in import for the available job types
-
-    TODO: this can also be a call to get a specific job type from the server
+    wrap the dynamic plug-in import for the available commands
     """
     subcmdplugins = getPlugins(subcmdpath, subcmdname, ['SubCommand'])
     result = {}


### PR DESCRIPTION
Put all possible config parameters in the client server-config mapping. Separate into a different mapping the client commands configuration. Remove loadMapping() function from SubCommand and use instead directly the mappings from ClientMapping.
Finally, very minor: print unique task name on submit output (because in the near future I would like to make the -t option to accept a unique task name as well).
