### PR TITLE
Whitelist an activity parameter in the General section.

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -13,6 +13,7 @@ file is used to set the same server parameter.
 
 parameters_mapping = {
     'on-server': {'workflow'       : {'default': None,       'config': ['General.requestName'],             'type': 'StringType',  'required': False},
+                  'activity'       : {'default': 'analysis-crab3', 'config': ['General.activity'],                'type': 'StringType',  'required': False},
                   'saveoutput'     : {'default': True,       'config': ['General.transferOutput'],          'type': 'BooleanType', 'required': False},
                   'savelogsflag'   : {'default': False,      'config': ['General.saveLogs'],                'type': 'BooleanType', 'required': False},
                   'faillimit'      : {'default': None,       'config': ['General.failureLimit'],            'type': 'IntType',     'required': False},


### PR DESCRIPTION
This will generalizing dmwm/CRABServer#4355 by allowing the user to specify a dashboard activity.

Submission tested, dashboard not yet verified due to schedd connectivity issues with my crab server.  Just wanted to bring this PR up for discussion.

See also dmwm/CRABServer#4416.
