### PR TITLE
If the output dataset name is returned, print it.

### DIFF
--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -161,9 +161,9 @@ class status(SubCommand):
             for status in  state_list[1:]:
                 if states[status]:
                     self.logger.info("\t\t\t\t{0} {1}".format(self._printState(status, 13), self._percentageString(status, states[status], total)))
-            if 'outdatasets' in dictresult and dictresult['outdatasets']:
-                self.logger.info("Output datasets:\t\t%s" % '\n\t\t\t\t'.join([out + ('\nOutput dataset url:\t\thttps://cmsweb.cern.ch/das/request?input=%s&instance=prod%%2Fphys03'\
-                                                       % urllib.quote(out, '')) for out in dictresult['outdatasets']]))
+        if 'outdatasets' in dictresult and dictresult['outdatasets']:
+            self.logger.info("Output datasets:\t\t%s" % '\n\t\t\t\t'.join([out + ('\nOutput dataset url:\t\thttps://cmsweb.cern.ch/das/request?input=%s&instance=prod%%2Fphys03'\
+                                                   % urllib.quote(out, '')) for out in dictresult['outdatasets']]))
 
 
     def printSummary(self, dictresult):


### PR DESCRIPTION
Needed for fix to dmwm/CRABServer#4372.  If the output dataset name is returned, the client should print it.
