### PR TITLE
Change option --skip-proxy to --proxy. Rename getUsername to getUsernameFromSiteDB. Fixes #4308, #4309.

### DIFF
--- a/doc/crabclient/userdoc/running.rst
+++ b/doc/crabclient/userdoc/running.rst
@@ -62,7 +62,7 @@ To perform the submission you can use the **submit** command of CRABClient:
        -h, --help            show this help message and exit
        -c FILE, --config=FILE
                              CRAB configuration file
-       -p USERDN, --skip-proxy=USERDN
+       --proxy=PROXYFILE
                              Skip Grid proxy creation and myproxy delegation
        -s http://HOSTNAME:PORT, --server=http://HOSTNAME:PORT
                              Endpoint server url to use

--- a/src/python/CRABAPI/Abstractions.py
+++ b/src/python/CRABAPI/Abstractions.py
@@ -16,7 +16,7 @@ class Task(object):
         """
             submit - Sends the current task to the server. Returns requestID
         """
-        args = ['-c', self.config, '--skip-proxy', '1']
+        args = ['-c', self.config, '--proxy', '1']
         submitCommand = self.submitClass(self.clientLog, args)
         retval = submitCommand()
         print "retval was %s" % retval

--- a/src/python/CRABClient/Commands/checkusername.py
+++ b/src/python/CRABClient/Commands/checkusername.py
@@ -1,11 +1,5 @@
-import os
-import string
-import commands
-import urllib
-
 from CRABClient.Commands.SubCommand import SubCommand
-from CRABClient.client_utilities import getUsername
-from CRABClient.client_exceptions import UsernameException
+from CRABClient.client_utilities import colors, getUserDNandUsernameFromSiteDB
 
 
 class checkusername(SubCommand):
@@ -24,42 +18,29 @@ class checkusername(SubCommand):
         return self.standaloneCheck()
 
 
-    def terminate(self, exitcode):
-        pass
-
-
     def standaloneCheck(self):
+        return getUserDNandUsernameFromSiteDB(self.logger)
 
-        self.logger.info('Attempting to extract your username from SiteDB...')
-        ## Direct stderr from voms-proxy-* to dev/null to avoid stupid Java messages :-(
-        status, dn = commands.getstatusoutput('eval `scram unsetenv -sh`; voms-proxy-info -identity 2>/dev/null')
-        if status:
-            self.logger.info('WARNING: Unable to retrieve your DN.')
-            return
-        self.logger.info('Your DN is: %s' % dn)
-        try:
-            username = getUsername()
-        except UsernameException:
-            self.logger.info("SiteDB returned no username for the above DN")
-        else:
-            self.logger.info("Your username is: %s" % username)
-        self.logger.info('Finished')
-
-        return {'DN': dn, 'username': username}
 
     def crabCheck(self):
-        self.logger.info('Attempting to extract your username from SiteDB...')
+
+        userdn = None
+        username = None
+        self.logger.info('Attempting to retrieve your username from SiteDB...')
         try:
             userdn = self.proxy.getUserDN()
             self.logger.info('Your DN is: %s' % userdn)
         except:
-            self.logger.info('WARNING: Unable to retrieve your DN.')
-        else:
-            try:
-                username = self.proxy.getHyperNewsName()
-                self.logger.info('Your username is: %s' % username)
-            except:
-                self.logger.info('WARNING: Unable to retrieve your username.')
-        self.logger.info('Finished')
-
+            self.logger.error('%Error%s: Unable to retrieve your DN from certificate.' % (colors.RED, colors.NORMAL))
+            return {'DN': userdn, 'username': username}
+        try:
+            username = self.proxy.getUsernameFromSiteDB()
+            self.logger.info('Your username is: %s' % username)
+        except:
+            self.logger.error('%Error%s: Unable to retrieve your username.' % (colors.RED, colors.NORMAL))
         return {'DN': userdn, 'username': username}
+
+
+    def terminate(self, exitcode):
+        pass
+

--- a/src/python/CRABClient/Commands/getcommand.py
+++ b/src/python/CRABClient/Commands/getcommand.py
@@ -65,7 +65,7 @@ class getcommand(SubCommand):
         cpresults = []
 #        for workflow in dictresult['result']: TODO re-enable this when we will have resubmissions
         workflow = dictresult['result']        #TODO assigning workflow to dictresult. for the moment we have only one wf
-        arglist = ['--destination', self.dest, '--input', workflow, '-t', self.options.task, '--skip-proxy', self.proxyfilename, '--parallel', self.options.nparallel, '--wait', self.options.waittime]
+        arglist = ['--destination', self.dest, '--input', workflow, '-t', self.options.task, '--proxy', self.proxyfilename, '--parallel', self.options.nparallel, '--wait', self.options.waittime]
         if len(workflow) > 0:
             if self.options.xroot:
                 self.logger.debug("XRootD urls are requested")

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -5,7 +5,7 @@ import math
 import optparse
 
 import CRABClient.Emulator
-from CRABClient.client_utilities import colors, getUserName
+from CRABClient.client_utilities import colors, getUsername
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.client_exceptions import MissingOptionException, RESTCommunicationException, ConfigurationException
 from CRABClient import __version__
@@ -122,7 +122,7 @@ class status(SubCommand):
             self.logger.info("Dashboard monitoring URL:\t%s" % dashurl)
 
         elif dictresult['jobSetID']:
-            username = urllib.quote(getUserName(self.voRole, self.voGroup, self.logger))
+            username = urllib.quote(getUsername(self.voRole, self.voGroup, self.logger))
             self.logger.info("Panda url:\t\t\thttp://pandamon-cms-dev.cern.ch/jobinfo?jobtype=*&jobsetID=%s&prodUserName=%s" % (dictresult['jobSetID'], username))
             # We have cases where the job def errors are there but we have a job def id
             logJDefErr(jdef=dictresult)

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -35,7 +35,7 @@ class submit(SubCommand):
     shortnames = ['sub']
 
 
-    def __init__(self, logger, cmdargs = []):
+    def __init__(self, logger, cmdargs = None):
         SubCommand.__init__(self, logger, cmdargs, disable_interspersed_args = True)
 
 

--- a/src/python/CRABClient/CredentialInteractions.py
+++ b/src/python/CRABClient/CredentialInteractions.py
@@ -76,20 +76,22 @@ class CredentialInteractions(object):
 
     def getUserDN(self):
         proxy = self.proxy()
-        return proxy.getSubjectFromCert(self.certLocation)
+        userdn = proxy.getSubjectFromCert(self.certLocation)
+        return userdn
 
 
-    def getHyperNewsName(self):
+    def getUsernameFromSiteDB(self):
         """
         Return a the client hypernews name
         """
         proxy = self.proxy()
         userdn = proxy.getSubjectFromCert(self.certLocation)
         sitedb = SiteDBJSON({"key": proxy.getProxyFilename(), "cert": proxy.getProxyFilename()})
-        return sitedb.dnUserName(userdn)
+        username = sitedb.dnUserName(userdn)
+        return username
 
 
-    def getUserName(self):
+    def getUsername(self):
         """
         Return user name form DN
         """

--- a/src/python/CRABClient/client_exceptions.py
+++ b/src/python/CRABClient/client_exceptions.py
@@ -51,22 +51,28 @@ class RESTCommunicationException(ClientException):
 
 class ProxyCreationException(ClientException):
     """
-    Raised when a there is a problem in proxy creation. exitcode > 2000 prints log
+    Raised when there is a problem in proxy creation. exitcode > 2000 prints log
     """
     exitcode = 3010
 
 class EnvironmentException(ClientException):
     """
-    Raised when a there is a problem in the environment where the client is executed.
+    Raised when there is a problem in the environment where the client is executed.
     E.g.: if the X509_CERT_DIR variable is not set we raise this exception
     """
     exitcode = 3011
 
 class UsernameException(ClientException):
     """
-    Raise when there is a problem with the username
+    Raised when there is a problem with the username (e.g. when retrieving it from SiteDB).
     """
     exitcode = 3012
+
+class ProxyException(ClientException):
+    """
+    Raised when there is a problem with the proxy (e.g. proxy file not found).
+    """
+    exitcode = 3013
 
 class PanDaException(ClientException):
     """


### PR DESCRIPTION
- Change option --skip-proxy to --proxy.
- Rename getHyperNewsName() function to getUsernameFromSiteDB() in CredentialInteractions.
- Rename getUseName() function to getUsername() in CredentialInteractions.
- Rename getUsername() function to getUsernameFromSiteDB() in client_utilities.
- Rename getUseName() function to getUsername() in client_utilities.
- New function getUserDN() in client_utilities.
- New wrapper functions getUsernameFromSiteDB_wrapped() and getUserDN_wrapped() in client_utilities, which respectively call getUsernameFromSiteDB() and getUserDN() catching exceptions and giving better error messages.
- New function getUserDNandUsernameFromSiteDB() in client_utilities, which calls the two wrapper functions above and returns the user DN and username in a dictionary.
- Use the new function getUserDNandUsernameFromSiteDB() in the checkusername command standalone method. 
- Use the new function getUserDNandUsernameFromSiteDB() in the checkwrite command, when the user did not specify the --lfn option, to retrieve the username. Before we were using getHyperNewsName() from  CredentialInteractions.
- When doing 'scram unsetenv -sh', do first 'which scram' to avoid error messages from scarm not being available.
