### PR TITLE
Improve readability of the log message in case there are multiple output datasets.

### DIFF
--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -188,8 +188,9 @@ class status(SubCommand):
                 if states[status]:
                     self.logger.info("\t\t\t\t{0} {1}".format(self._printState(status, 13), self._percentageString(status, states[status], total)))
         if 'outdatasets' in dictresult and dictresult['outdatasets']:
-            self.logger.info("Output datasets:\t\t%s" % '\n\t\t\t\t'.join([out + ('\nOutput dataset url:\t\thttps://cmsweb.cern.ch/das/request?input=%s&instance=prod%%2Fphys03'\
-                                                   % urllib.quote(out, '')) for out in dictresult['outdatasets']]))
+            info = '\nOutput dataset:\t\t\t{0}'\
+                   '\nOutput dataset url:\t\thttps://cmsweb.cern.ch/das/request?input={1}&instance=prod%%2Fphys03'
+            self.logger.info(''.join([info.format(o, urllib.quote(o, '')) for o in dictresult['outdatasets']]))
 
 
     def printSummary(self, dictresult):


### PR DESCRIPTION
To improve readability, change:
![screen shot 2014-11-03 at 3 08 43 pm](https://cloud.githubusercontent.com/assets/5114833/4898145/64211f36-640d-11e4-816b-e0e8455e7e69.png)
to
![screen shot 2014-11-03 at 3 11 45 pm](https://cloud.githubusercontent.com/assets/5114833/4898149/6a106da2-640d-11e4-9773-4291a9bddd77.png)
