### PR TITLE
Add option to use the parent dataset.

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -21,6 +21,7 @@ parameters_mapping = {
                                                                         'Data.primaryDataset'],             'type': 'StringType',  'required': False},
                   'userfiles'      : {'default': None,       'config': ['Data.userInputFile'],              'type': 'StringType',  'required': False},
                   'dbsurl'         : {'default': 'global',   'config': ['Data.inputDBS'],                   'type': 'StringType',  'required': False},
+                  'useparent'      : {'default': None,       'config': ['Data.useParent'],                  'type': 'BooleanType', 'required': False},
                   'ignorelocality' : {'default': False,      'config': ['Data.ignoreLocality'],             'type': 'BooleanType', 'required': False},
                   'splitalgo'      : {'default': None,       'config': ['Data.splitting'],                  'type': 'StringType',  'required': True },
                   'algoargs'       : {'default': None,       'config': ['Data.unitsPerJob'],                'type': 'IntType',     'required': True },

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -97,7 +97,7 @@ class submit(SubCommand):
                 if mustbetype == type(self.requestname):
                     configreq['workflow'] = self.requestname
             ## Translate boolean flags into integers.
-            elif param in ['savelogsflag', 'publication', 'nonprodsw', 'ignorelocality', 'saveoutput', 'oneEventMode']:
+            elif param in ['savelogsflag', 'publication', 'nonprodsw', 'useparent', 'ignorelocality', 'saveoutput', 'oneEventMode']:
                 configreq[param] = 1 if temp else 0
             ## Translate DBS URL aliases into DBS URLs.
             elif param in ['dbsurl', 'publishdbsurl']:


### PR DESCRIPTION
This is in preparation for the `use_parent` implementation in CRABServer to get en par with CRAB2.
