### PR TITLE
Better printout layout in getcommand.

### DIFF
--- a/src/python/CRABClient/Commands/getcommand.py
+++ b/src/python/CRABClient/Commands/getcommand.py
@@ -76,7 +76,18 @@ class getcommand(SubCommand):
             elif self.dump:
                 jobid_pfn_lfn_list = map(lambda x: (x['jobid'], x['pfn'], x['lfn']), workflow)
                 jobid_pfn_lfn_list.sort()
-                self.logger.info('\n'.join(["=== Files from job %s\nPFN: %s\nLFN: %s" % (jobid, pfn, lfn) for jobid, pfn, lfn in jobid_pfn_lfn_list]))
+                lastjobid = -1
+                filecounter = 1
+                msg = ""
+                for jobid, pfn, lfn in jobid_pfn_lfn_list:
+                    if jobid != lastjobid:
+                        msg += "%s=== Files from job %s:" % ('\n' if lastjobid != -1 else '', jobid)
+                        lastjobid = jobid
+                        filecounter = 1
+                    msg += "\n%d) PFN: %s" % (filecounter, pfn)
+                    msg += "\n%s  LFN: %s" % (' '*(len(str(filecounter))), lfn)
+                    filecounter += 1
+                self.logger.info(msg)
                 returndict = {'pfn': [pfn for _, pfn, _ in jobid_pfn_lfn_list], 'lfn': [lfn for _, _, lfn in jobid_pfn_lfn_list]}
             else:
                 self.logger.info("Retrieving %s files" % totalfiles )


### PR DESCRIPTION
Before:

$ crab getoutput -d crab_test_toT_tlF_1 --dump
=== Files from job 2
PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_2.lhe
LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_2.lhe
=== Files from job 2
PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_2.root
LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_2.root
=== Files from job 2
PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_2.root
LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_2.root
=== Files from job 3
PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_3.lhe
LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_3.lhe
=== Files from job 3
PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_3.root
LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_3.root
=== Files from job 3
PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_3.root
LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_3.root

After:

$ crab getoutput -d crab_test_toT_tlF_1 --dump
=== Files from job 2:
1) PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_2.lhe
   LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_2.lhe
2) PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_2.root
   LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_2.root
3) PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_2.root
   LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_2.root
=== Files from job 3:
1) PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_3.lhe
   LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/ggH_Hmass125_hfact4.95_Bmass0_seed001_3.lhe
2) PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_3.root
   LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/pooloutputmodule_3.root
3) PFN: srm://dcache07.unl.edu:8443/srm/v2/server?SFN=/mnt/hadoop/user/uscms01/pnfs/unl.edu/data4/cms/store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_3.root
   LFN: /store/user/atanasi/GenericTTbar/test_toT_tlF_1/141205_100859/0000/tfileservice_3.root
