### PR TITLE
Add username to uploaded log file url. 

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -116,34 +116,39 @@ class CRABClient(object):
 
             Adapted from Doug Hellmann
             """
-            ## feedback email address
-
-            feebackemail = 'hn-cms-computing-tools@cern.ch'
+            ## Feedback email address
+            feedbackemail = 'hn-cms-computing-tools@cern.ch'
 
             #adding a file handler
             clientinstance = self
             filehandler = logging.FileHandler(client.logger.logfile)
             logging.getLogger('CRAB3').addHandler(filehandler)
 
-            # This goes to the console
+            ## This goes to the console.
             logging.getLogger('CRAB3.all').error("ERROR: %s: %s" % (exc_type.__name__, exc_value))
-            logging.getLogger('CRAB3.all').error("\n\tPlease email %s for support with the crab.log file or crab.log url." % feebackemail)
+            logging.getLogger('CRAB3.all').error("\n\tPlease email %s for support with the crab.log file or crab.log URL." % (feedbackemail))
             logging.getLogger('CRAB3.all').error("\tClient Version: %s" % client_version)
-            # This goes to the log file
+            ## This goes to the crab log file.
             tbLogger = logging.getLogger('CRAB3')
             tbLogger.error("Unhandled Exception!")
-            tbLogger.error(exc_value, exc_info=(exc_type, exc_value, tback))
+            tbLogger.error(exc_value, exc_info = (exc_type, exc_value, tback))
 
-            #uploading log file
-            if hasattr(clientinstance, 'cmd') and hasattr(clientinstance.cmd , 'proxyfilename') and clientinstance.cmd.proxyfilename != None:
+            ## Uploading the crab log file.
+            if hasattr(clientinstance, 'cmd') and hasattr(clientinstance.cmd, 'proxyfilename') and clientinstance.cmd.proxyfilename != None:
+                username = ''
+                if hasattr(clientinstance.cmd, 'proxyusername'):
+                    username = clientinstance.cmd.proxyusername
                 try:
-                    logurl = uploadlogfile(tbLogger, clientinstance.cmd.proxyfilename, logfilename = None, logpath = str(client.logger.logfile), instance = 'prod')
-                    logging.getLogger('CRAB3.all').error('\tThe log file has been upload automatically, please email the following url %s to %s' % (logurl, feebackemail))
+                    logurl = uploadlogfile(tbLogger, clientinstance.cmd.proxyfilename, logfilename = None, \
+                                           logpath = str(client.logger.logfile), instance = 'prod', username = username)
+                    msg  = "\tThe log file %s has been uploaded automatically." % (client.logger.logfile)
+                    msg += "\n\tPlease email the following URL '%s' to %s." % (logurl, feedbackemail)
+                    logging.getLogger('CRAB3.all').error(msg)
                 except Exception:
-                    logging.getLogger('CRAB3.all').debug('Failed to upload file automatically')
-                    logging.getLogger('CRAB3.all').error('\tPlease use crab uploadlog to upload the log file: %s' %client.logger.logfile )
+                    logging.getLogger('CRAB3.all').debug('Failed to upload log file automatically')
+                    logging.getLogger('CRAB3.all').error('\tPlease use crab uploadlog to upload the log file %s' % (client.logger.logfile))
             else:
-                logging.getLogger('CRAB3.all').error('\tPlease use crab uploadlog to upload the log file: %s' %client.logger.logfile )
+                logging.getLogger('CRAB3.all').error('\tPlease use crab uploadlog to upload the log file %s' % (client.logger.logfile))
 
         sys.excepthook = log_exception
 

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -212,6 +212,9 @@ class SubCommand(ConfigCommand):
         if not self.options.proxy and self.cmdconf['initializeProxy']:
             self.proxy_created = self.proxy.createNewVomsProxySimple(time_left_threshold = 720)
 
+        ## Extract the username from the proxy.
+        self.proxyusername = self.proxy.getUsername()
+
         ## If we get an input configuration file:
         if hasattr(self.options, 'config') and self.options.config is not None:
             ## Load the configuration file and validate it.
@@ -269,7 +272,6 @@ class SubCommand(ConfigCommand):
         self.logger.debug("Server base url is %s" %(self.serverurl))
         if self.cmdconf['requiresREST']:
             self.logger.debug("Command url %s" %(self.uri))
-
 
     def serverInstance(self):
         """

--- a/src/python/CRABClient/Commands/checkusername.py
+++ b/src/python/CRABClient/Commands/checkusername.py
@@ -23,7 +23,6 @@ class checkusername(SubCommand):
 
 
     def crabCheck(self):
-
         userdn = None
         username = None
         self.logger.info('Attempting to retrieve your username from SiteDB...')

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -3,7 +3,7 @@ import urllib
 import math
 
 import CRABClient.Emulator
-from CRABClient.client_utilities import colors, getUsername
+from CRABClient.client_utilities import colors
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.client_exceptions import RESTCommunicationException, ConfigurationException
 from CRABClient import __version__
@@ -121,7 +121,6 @@ class status(SubCommand):
             self.logger.info("Dashboard monitoring URL:\t%s" % dashurl)
 
         elif dictresult['jobSetID']:
-            username = urllib.quote(getUsername(self.voRole, self.voGroup, self.logger))
             self.logger.info("Panda url:\t\t\thttp://pandamon-cms-dev.cern.ch/jobinfo?jobtype=*&jobsetID=%s&prodUserName=%s" % (dictresult['jobSetID'], username))
             # We have cases where the job def errors are there but we have a job def id
             logJDefErr(jdef=dictresult)

--- a/src/python/CRABClient/Commands/uploadlog.py
+++ b/src/python/CRABClient/Commands/uploadlog.py
@@ -28,9 +28,9 @@ class uploadlog(SubCommand):
             self.logger.info("%sError:%s Could not locate log file" % (colors.RED, colors.NORMAL))
             raise ConfigurationException
 
-        logfileurl = uploadlogfile(self.logger, self.proxyfilename, logfilename = logfilename, logpath = str(self.logfile), instance = self.instance, serverurl = self.serverurl)
-
-
+        logfileurl = uploadlogfile(self.logger, self.proxyfilename, logfilename = logfilename, \
+                                   logpath = str(self.logfile), instance = self.instance, \
+                                   serverurl = self.serverurl, username = self.proxyusername)
         return {'result' : {'status' : 'SUCCESS' , 'logurl' : logfileurl}}
 
     def setOptions(self):

--- a/src/python/CRABClient/CredentialInteractions.py
+++ b/src/python/CRABClient/CredentialInteractions.py
@@ -80,6 +80,12 @@ class CredentialInteractions(object):
         return userdn
 
 
+    def getUsername(self):
+        proxy = self.proxy()
+        username = proxy.getUsername()
+        return username
+
+
     def getUsernameFromSiteDB(self):
         """
         Return a the client hypernews name
@@ -91,9 +97,9 @@ class CredentialInteractions(object):
         return username
 
 
-    def getUsername(self):
+    def getUserName(self):
         """
-        Return user name form DN
+        Return user name from DN
         """
         proxy = self.proxy()
         return proxy.getUserName()


### PR DESCRIPTION
1. In client_utilities::getUsernameFromSiteDB(), convert retrieved username from SiteDB from 'null' to None.
2. In checkusername command, if username retrieved from SiteDB is None (because of 1., this includes username = 'null', and I think is actually the only case), give an appropriate error message. Before we were printing for example "Username is: null".
3. Add username to the upload log file url returned to the user.

Requires https://github.com/dmwm/WMCore/pull/5513.
