### PR TITLE
Change --cmptask option name in remake command to --task. Fixes #4346

### DIFF
--- a/src/python/CRABClient/Commands/remake.py
+++ b/src/python/CRABClient/Commands/remake.py
@@ -49,7 +49,7 @@ class remake(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option( '--cmptask',
+        self.parser.add_option( '--task',
                                 dest = 'cmptask',
                                 default = None,
                                 help = 'The complete task name from glidemon or dashboard.')
@@ -57,7 +57,7 @@ class remake(SubCommand):
     def validateOptions(self):
 
         if not hasattr(self.options, 'cmptask') or  self.options.cmptask == None :
-            raise MissingOptionException("%sError%s: Please use the --cmptask option to specify the complete task name "% (colors.RED,colors.NORMAL))
+            raise MissingOptionException("%sError%s: Please use the --task option to specify the complete task name "% (colors.RED,colors.NORMAL))
         elif not re.match('^\d{6}_\d{6}_([^\:\,]+)\:[a-zA-Z]+_crab_.+' ,self.options.cmptask):
             raise  ConfigurationException('%sError%s: Task name given did not meet regular expression citeria' % (colors.RED, colors.NORMAL))
 


### PR DESCRIPTION
Change --cmptask to --task for crab remake, and to the error msg if the user uses other than --task.
