### PR TITLE
Get username from SiteDB when uploading log file.

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -135,12 +135,9 @@ class CRABClient(object):
 
             ## Uploading the crab log file.
             if hasattr(clientinstance, 'cmd') and hasattr(clientinstance.cmd, 'proxyfilename') and clientinstance.cmd.proxyfilename != None:
-                username = ''
-                if hasattr(clientinstance.cmd, 'proxyusername'):
-                    username = clientinstance.cmd.proxyusername
                 try:
                     logurl = uploadlogfile(tbLogger, clientinstance.cmd.proxyfilename, logfilename = None, \
-                                           logpath = str(client.logger.logfile), instance = 'prod', username = username)
+                                           logpath = str(client.logger.logfile), instance = 'prod')
                     msg  = "\tThe log file %s has been uploaded automatically." % (client.logger.logfile)
                     msg += "\n\tPlease email the following URL '%s' to %s." % (logurl, feedbackemail)
                     logging.getLogger('CRAB3.all').error(msg)

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -212,9 +212,6 @@ class SubCommand(ConfigCommand):
         if not self.options.proxy and self.cmdconf['initializeProxy']:
             self.proxy_created = self.proxy.createNewVomsProxySimple(time_left_threshold = 720)
 
-        ## Extract the username from the proxy.
-        self.proxyusername = self.proxy.getUsername()
-
         ## If we get an input configuration file:
         if hasattr(self.options, 'config') and self.options.config is not None:
             ## Load the configuration file and validate it.

--- a/src/python/CRABClient/Commands/uploadlog.py
+++ b/src/python/CRABClient/Commands/uploadlog.py
@@ -30,7 +30,7 @@ class uploadlog(SubCommand):
 
         logfileurl = uploadlogfile(self.logger, self.proxyfilename, logfilename = logfilename, \
                                    logpath = str(self.logfile), instance = self.instance, \
-                                   serverurl = self.serverurl, username = self.proxyusername)
+                                   serverurl = self.serverurl)
         return {'result' : {'status' : 'SUCCESS' , 'logurl' : logfileurl}}
 
     def setOptions(self):

--- a/src/python/CRABClient/client_utilities.py
+++ b/src/python/CRABClient/client_utilities.py
@@ -154,7 +154,7 @@ def uploadlogfile(logger, proxyfilename, logfilename = None, logpath = None, ins
     elif not instance in SERVICE_INSTANCES.keys() and serverurl != None:
         instance = 'private'
     elif not instance in SERVICE_INSTANCES.keys() and serverurl == None:
-        logger.debug('%sError%s: serverurl is None' %(colors.RED, colors.NORMAL))
+        logger.debug('%sError%s: serverurl is None' % (colors.RED, colors.NORMAL))
         doupload = False
 
     if proxyfilename == None:
@@ -169,12 +169,15 @@ def uploadlogfile(logger, proxyfilename, logfilename = None, logpath = None, ins
 
         ufc = UserFileCache(cacheurldict)
         logger.debug("cacheURL: %s\nLog file name: %s" % (cacheurl, logfilename))
-        logger.info("Uploading log file")
+        logger.info("Uploading log file...")
         ufc.uploadLog(logpath, logfilename)
+        logger.info("%sSuccess%s: Log file uploaded successfully." % (colors.GREEN, colors.NORMAL))
         logfileurl = cacheurl + '/logfile?name='+str(logfilename)
+        if not username:
+            username = getUsernameFromSiteDB_wrapped(logger, quiet = True)
         if username:
             logfileurl += '&username='+str(username)
-        logger.info("Log file url: %s" % (logfileurl))
+        logger.info("Log file URL: %s" % (logfileurl))
         return  logfileurl
     else:
         logger.info('Failed to upload the log file')
@@ -474,13 +477,17 @@ def getUsernameFromSiteDB():
     return username
 
 
-def getUsernameFromSiteDB_wrapped(logger):
+def getUsernameFromSiteDB_wrapped(logger, quiet = False):
     """
     Wrapper function for getUsernameFromSiteDB,
     catching exceptions and printing messages.
     """
     username = None
-    logger.info('Retrieving username from SiteDB...')
+    msg = "Retrieving username from SiteDB..."
+    if quiet:
+        logger.debug(msg)
+    else:
+        logger.info(msg)
     infomsg  = "\n%sNote%s: Make sure you have the correct certificate mapped in SiteDB" % (colors.BOLD, colors.NORMAL)
     infomsg += " (you can check what is the certificate you currently have mapped in SiteDB"
     infomsg += " by searching for your name in https://cmsweb.cern.ch/sitedb/prod/people)."
@@ -489,18 +496,31 @@ def getUsernameFromSiteDB_wrapped(logger):
         username = getUsernameFromSiteDB()
         if not username:
             raise
-        logger.info("Username is: %s" % username)
+        msg = "Username is: %s" % (username)
+        if quiet:
+            logger.debug(msg)
+        else:
+            logger.info(msg)
     except ProxyException, ex:
         msg = "%sError%s: %s" % (colors.RED, colors.NORMAL, ex)
-        logger.error(msg)
+        if quiet:
+            logger.debug(msg)
+        else:        
+            logger.error(msg)
     except UsernameException, ex:
         msg = "%sError%s: %s" % (colors.RED, colors.NORMAL, ex)
         msg += infomsg
-        logger.error(msg)
+        if quiet:
+            logger.debug(msg)
+        else:
+            logger.error(msg)
     except:
         msg = "%sError%s: Unable to retrieve username from SiteDB." % (colors.RED, colors.NORMAL)
         msg += infomsg
-        logger.error(msg)
+        if quiet:
+            logger.debug(msg)
+        else:
+            logger.error(msg)
     return username
 
 


### PR DESCRIPTION
Tests:

$ crab uploadlog -d crab_test_cmscp_no_local_stgout_tlT_toT_1
Fetching user enviroment to log file
Uploading log file...
Success: Log file uploaded successfully.
Log file URL: https://cmsweb-testbed.cern.ch/crabcache/logfile?name=141210_153826_crab3test-5:atanasi_crab_test_cmscp_no_local_stgout_tlT_toT_1.log&username=atanasi
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_test_cmscp_no_local_stgout_tlT_toT_1/crab.log

In case of not being able to retrieve username from SiteDB:
$ crab uploadlog -d crab_test_cmscp_no_local_stgout_tlT_toT_1
Fetching user enviroment to log file
Uploading log file...
Success: Log file uploaded successfully.
Log file URL: https://cmsweb-testbed.cern.ch/crabcache/logfile?name=141210_153826_crab3test-5:atanasi_crab_test_cmscp_no_local_stgout_tlT_toT_1.log
Log file is /afs/cern.ch/work/a/atanasi/CRAB3-tutorial/CMSSW_7_0_5/src/crab_test_cmscp_no_local_stgout_tlT_toT_1/crab.log
