### PR TITLE
Pass options (maxmemory, maxjobruntime, numcores, priority) to server in resubmit command

### DIFF
--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -75,7 +75,7 @@ class ConfigCommand:
             valid, configmsg = self.validateConfig() #subclasses of SubCommand overrhide this if needed
         except RuntimeError, re:
             msg = self._extractReason(configname, re)
-            raise ConfigurationException("Configuration syntax error:\n%s\nPlease refer to <https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3CommonErrors#Configuration_syntax_error>\nSee the ./crab.log file for more details" % msg)
+            raise ConfigurationException("Configuration syntax error:\n%s\nPlease refer to https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3CommonErrors#Configuration_syntax_error\nSee the ./crab.log file for more details" % msg)
         else:
             ## file is there, check if it is ok
             if not valid:

--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -1,97 +1,136 @@
 from CRABClient.Commands.SubCommand import SubCommand
-from CRABClient.client_exceptions import ConfigException, RESTCommunicationException
+from CRABClient.client_exceptions import ConfigurationException, RESTCommunicationException
 from CRABClient.client_utilities import validateJobids
 from CRABClient import __version__
 import CRABClient.Emulator
 
-from urllib import urlencode
 import re
-
+import urllib
 
 class resubmit(SubCommand):
     """
     Resubmit the failed jobs of the task identified by the -d/--dir option.
     """
+    def __init__(self, logger, cmdargs = None):
+        """
+        Class constructor.
+        """
+        self.jobids        = None
+        self.sitewhitelist = None
+        self.siteblacklist = None
+        self.maxjobruntime = None
+        self.maxmemory     = None
+        self.numcores      = None
+        self.priority      = None
+
+        SubCommand.__init__(self, logger, cmdargs)
+
+
     def __call__(self):
+
         serverFactory = CRABClient.Emulator.getEmulator('rest')
-        server = serverFactory(self.serverurl, self.proxyfilename, self.proxyfilename, version=__version__)
+        server = serverFactory(self.serverurl, self.proxyfilename, self.proxyfilename, version = __version__)
 
-        self.logger.debug('Requesting resubmission for failed jobs in task %s' % self.cachedinfo['RequestName'] )
-        configreq = { 'workflow' : self.cachedinfo['RequestName']}
+        msg = "Requesting resubmission for failed jobs in task %s" % (self.cachedinfo['RequestName'])
+        self.logger.debug(msg)
 
-        for attr in ['maxmemory', 'maxjobruntime', 'numcores', 'priority']:
-            val = getattr(self, attr, None)
-            if val:
-                configreq[attr] = val
+        configreq = {'workflow': self.cachedinfo['RequestName']}
+        for attr_name in ['jobids', 'sitewhitelist', 'siteblacklist', 'maxjobruntime', 'maxmemory', 'numcores', 'priority']:
+            attr_value = getattr(self, attr_name)
+            if attr_value:
+                configreq[attr_name] = attr_value
 
-        dictresult, status, reason = server.post(self.uri, data = urlencode({ 'workflow' : self.cachedinfo['RequestName']}) + \
-                                                    self.sitewhitelist + self.siteblacklist + '&' + urlencode(self.jobids))
-        self.logger.debug("Result: %s" % dictresult)
+        self.logger.info("Sending the request to the server")
+        self.logger.debug("Submitting %s " % str(configreq))
+        ## TODO: this shouldn't be hard-coded.
+        listParams = ['jobids', 'sitewhitelist', 'siteblacklist']
+        configreq_encoded = self._encodeRequest(configreq, listParams)
+        self.logger.debug("Encoded resubmit request: %s" % (configreq_encoded))
 
+        dictresult, status, reason = server.post(self.uri, data = configreq_encoded)
+        self.logger.debug("Result: %s" % (dictresult))
         if status != 200:
-            msg = "Problem retrieving resubmitting the task to the server:\ninput:%s\noutput:%s\nreason:%s" % (str(inputdict), str(dictresult), str(reason))
+            msg = "Problem resubmitting the task to the server:\ninput:%s\noutput:%s\nreason:%s" \
+                  % (str(data), str(dictresult), str(reason))
             raise RESTCommunicationException(msg)
-
-        self.logger.info("Resubmit request successfully sent")
+        msg = "Resubmit request successfuly sent to the CRAB3 server."
         if dictresult['result'][0]['result'] != 'ok':
-            self.logger.info(dictresult['result'][0]['result'])
-            returndict = {'status' : 'FAILED'}
+            msg += "\nServer responded with: '%s'" % (dictresult['result'][0]['result'])
+            returndict = {'status': 'FAILED'}
         else:
-            returndict = {'status' : 'SUCCESS'}
+            returndict = {'status': 'SUCCESS'}
+        self.logger.info(msg)
 
         return returndict
+
+
+    ## TODO: This method is shared with submit. Put it in a common place.
+    def _encodeRequest(self, configreq, listParams):
+        """
+        Similar method as in submit.
+        """
+        encodedLists = ''
+        for lparam in listParams:
+            if lparam in configreq:
+                if len(configreq[lparam]) > 0:
+                    encodedLists += ('&%s=' % lparam) + ('&%s=' % lparam).join(map(urllib.quote, configreq[lparam]))
+                del configreq[lparam]
+        encoded = urllib.urlencode(configreq) + encodedLists
+        return str(encoded)
+
 
     def setOptions(self):
         """
         __setOptions__
 
-        This allows to set specific command options
+        This allows to set specific command options.
         """
-        self.parser.add_option( "--blacklist",
-                                 dest = 'siteblacklist',
-                                 default = None,
-                                 help = "Set the sites you want to blacklist during the resubmission." + \
-                                            " Comma separated list of cms sites (e.g.: T2_ES_CIEMAT,T2_IT_Rome[...]).")
+        self.parser.add_option('--jobids',
+                               dest = 'jobids',
+                               default = None,
+                               help = "The ids of the jobs to resubmit. Comma separated list of integers.",
+                               metavar = 'JOBIDS')
 
-        self.parser.add_option( "--whitelist",
-                                 dest = 'sitewhitelist',
-                                 default = None,
-                                 help = "Set the sites you want to whitelist during the resubmission." + \
-                                            " Comma separated list of cms sites (e.g.: T2_ES_CIEMAT,T2_IT_Rome[...]).")
+        self.parser.add_option('--whitelist',
+                               dest = 'sitewhitelist',
+                               default = None,
+                               help = "Set the sites you want to whitelist for the resubmission." + \
+                                      " Comma separated list of CMS site names (e.g.: T2_ES_CIEMAT,T2_IT_Rome[...]).")
 
-        self.parser.add_option( "--memory",
-                                 dest = 'maxmemory',
-                                 default = None,
-                                 type = "int",
-                                 help = "Set the maximum memory used per job in this task." + \
-                                            " This is in units of MB (e.g.: 2000 for 2GB of RAM).")
+        self.parser.add_option('--blacklist',
+                               dest = 'siteblacklist',
+                               default = None,
+                               help = "Set the sites you want to blacklist for the resubmission." + \
+                                      " Comma separated list of CMS site names (e.g.: T2_ES_CIEMAT,T2_IT_Rome[...]).")
 
-        self.parser.add_option( "--cores",
-                                 dest = 'numcores',
-                                 default = None,
-                                 type = "int",
-                                 help = "Set the number of cores used per job in this task." + \
-                                            " (e.g.: 1 for single-threaded applications).")
+        self.parser.add_option('--walltime',
+                               dest = 'maxjobruntime',
+                               default = None,
+                               type = 'int',
+                               help = "Set the maximum time (in minutes) jobs in this task are allowed to run." + \
+                                      " Default is 1315 (21 hours 50 minutes).")
 
-        self.parser.add_option( "--priority",
-                                 dest = 'priority',
-                                 default = None,
-                                 type = "int",
-                                 help = "Set the priority of this task compared to other tasks you own; tasks default to 10." + \
-                                            " This does not improve your share compared to other users.")
+        self.parser.add_option('--memory',
+                               dest = 'maxmemory',
+                               default = None,
+                               type = 'int',
+                               help = "Set the maximum memory (in MB) used per job in this task." + \
+                                      " Default is 2000.")
 
-        self.parser.add_option( "--wall",
-                                 dest = 'maxjobruntime',
-                                 default = None,
-                                 type = "int",
-                                 help = "Set the maximum time, in hours, jobs in this task are allowed to run." + \
-                                            " Default is 24 hours.")
+        self.parser.add_option('--cores',
+                               dest = 'numcores',
+                               default = None,
+                               type = 'int',
+                               help = "Set the number of cores used per job in this task." + \
+                                      " (e.g.: 1 for single-threaded applications).")
 
-        self.parser.add_option( '--jobids',
-                                dest = 'jobids',
-                                default = None,
-                                help = 'Ids of the jobs you want to resubmit. Comma separated list of integers',
-                                metavar = 'JOBIDS' )
+        self.parser.add_option('--priority',
+                               dest = 'priority',
+                               default = None,
+                               type = 'int',
+                               help = "Set the priority of this task compared to other tasks you own; tasks default to 10." + \
+                                      " This does not improve your share compared to other users.")
+
 
     def validateOptions(self):
         """
@@ -99,6 +138,11 @@ class resubmit(SubCommand):
         and put the strings to be passed to the server to self
         """
         SubCommand.validateOptions(self)
+
+        ## Check the format of the jobids option.
+        if getattr(self.options, 'jobids'):
+            jobidstuple = validateJobids(self.options.jobids)
+            self.jobids = [str(jobid) for (_, jobid) in jobidstuple]
 
         #Checking if the sites provided by the user are valid cmsnames. Doing this because with only the
         #server error handling we get:
@@ -108,46 +152,35 @@ class resubmit(SubCommand):
         #Moreover, I prefer to be independent from Lexicon. I'll the regex here.
         sn_re = "^T[1-3]_[A-Z]{2}(_[A-Za-z0-9]+)+$" #sn_re => SiteName_RegularExpression
         sn_rec = re.compile(sn_re) #sn_rec => SiteName_RegularExpressionCompiled
+        for sitelist in ['sitewhitelist', 'siteblacklist']:
+            if getattr(self.options, sitelist) is not None:
+                for i, site_name in enumerate(getattr(self.options, sitelist).split(',')):
+                    if not sn_rec.match(site_name):
+                        msg  = "The site name %s does not look like a valid CMS site name" % (site_name)
+                        msg += " (it is not matching the regular expression %s)." % (sn_re)
+                        raise ConfigurationException(msg)
+                setattr(self, sitelist, getattr(self.options, sitelist).split(','))
 
-        self.sitewhitelist = ''
-        self.siteblsklist = ''
-
-        for siteList in ['sitewhitelist', 'siteblacklist']:
-            result = ''
-            paramVal = getattr(self.options, siteList, None)
-            if paramVal:
-                for site in paramVal.split(','):
-                    if not sn_rec.match(site):
-                        raise ConfigException("The sitename %s dows not look like a valid CMS name (not matching %s)" % (site, sn_re) )
-                    result += "&%s=%s" % (siteList, site)
-            setattr(self, siteList, result)
-
-        #check the format of jobids
-        self.jobids = ''
-        if getattr(self.options, 'jobids', None):
-            self.jobids = validateJobids(self.options.jobids)
-
-        # Sanity checks for task sizes.  Limits are purposely fairly generous to provide some level of future-proofing.
-        # The server may restrict further.
-        self.numcores = None
-        if self.options.numcores != None:
-            if self.options.numcores < 1 or self.options.numcores > 128:
-                raise ConfigException("The number of requested cores (%d) must be between 1 and 128." % (self.options.numcores))
-            self.numcores = str(self.options.numcores)
-
-        self.maxjobruntime = None
-        if self.options.maxjobruntime != None:
-            if self.options.maxjobruntime < 1 or self.options.maxjobruntime > 336:
-                raise ConfigException("The requested max job runtime (%d hours) must be between 1 and 336 hours." % self.options.maxjobruntime)
+        ## Sanity checks for task sizes. Limits are purposely fairly generous to provide
+        ## some level of future-proofing. The server may restrict further.
+        if self.options.maxjobruntime is not None:
+            if self.options.maxjobruntime < 60 or self.options.maxjobruntime > 336*60:
+                msg = "The requested maximum job runtime (%d minutes) must be between 60 and 20160 minutes." % (self.options.maxjobruntime)
+                raise ConfigurationException(msg)
             self.maxjobruntime = str(self.options.maxjobruntime)
 
-        self.maxmemory = None
-        if self.options.maxmemory != None:
+        if self.options.maxmemory is not None:
             if self.options.maxmemory < 30 or self.options.maxmemory > 1024*30:
-                raise ConfigException("The requested per-job memory (%d MB) must be between 30 and 30720 MB." % self.options.maxmemory)
+                msg = "The requested per-job memory (%d MB) must be between 30 and 30720 MB." % (self.options.maxmemory)
+                raise ConfigurationException(msg)
             self.maxmemory = str(self.options.maxmemory)
 
-        self.priority = None
-        if self.options.priority != None:
+        if self.options.numcores is not None:
+            if self.options.numcores < 1 or self.options.numcores > 128:
+                msg = "The requested number of cores (%d) must be between 1 and 128." % (self.options.numcores)
+                raise ConfigurationException(msg)
+            self.numcores = str(self.options.numcores)
+
+        if self.options.priority is not None:
             self.priority = str(self.options.priority)
 

--- a/src/python/CRABClient/client_utilities.py
+++ b/src/python/CRABClient/client_utilities.py
@@ -557,7 +557,9 @@ def validateJobids(jobids):
         jobid = list(set(jobid))
         return [('jobids', job) for job in jobid]
     else:
-        raise ConfigurationException("The command line option jobids should be a comma separated list of integers or range, no whitespace")
+        msg  = "The command line option --jobids takes a comma separated list of"
+        msg += " integers or ranges, without whitespaces."
+        raise ConfigurationException(msg)
 
 
 #XXX Trying to do it as a Command causes a lot of headaches (and workaround code).


### PR DESCRIPTION
This PR intends to fix the following issue: The command crab resubmit accepts a few command line options on top of the obvious --jobids. These other options are: site white/black list, maxmemory, maxjobruntime, numcores and priority. But currently only the --jobids option works. Fixing this requires the client to correctly send the option values to the server and the server correctly read them from the database and pass them to condor. This PR in the client fixes the first. The option values are written into the TaskDB tm_arguments column, which we kind of agreed with Marco that this column should be used for non-static parameters, while static parameters should have each its own column in the TaskDB (will open a GH issue for that).

I tested this patch in my private WM, and it works, in the sense that the parameters are written in the correct place in the DB and with the correct values. The ticket for this issue is https://github.com/dmwm/CRABServer/issues/4501
