### PR TITLE
Add protection to avoid PrivateMC with inputDataset.

### DIFF
--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -57,16 +57,21 @@ class report(SubCommand):
                     for rep in val:
                         pfiles = pfiles.union(set(literal_eval(rep['parents'])))
                 return len(pfiles)
-            self.logger.info("%d files have been processed" % _getNumFiles(poolInOnlyRes))
+            numFilesProcessed = _getNumFiles(poolInOnlyRes)
+            self.logger.info("%d file%s been processed" % (numFilesProcessed, " has" if numFilesProcessed == 1 else "s have"))
             def _getNumEvents(jobs, type):
                 for jn, val in jobs.iteritems():
                     yield sum([ x['events'] for x in val if x['type'] == type])
-            self.logger.info("%d events have been read" % sum(_getNumEvents(dictresult['result'][0]['runsAndLumis'], 'POOLIN')))
-            self.logger.info("%d events have been written" % sum(_getNumEvents(dictresult['result'][0]['runsAndLumis'], 'EDM')))
+            numEventsRead = sum(_getNumEvents(dictresult['result'][0]['runsAndLumis'], 'POOLIN'))
+            self.logger.info("%d event%s been read" % (numEventsRead, " has" if numEventsRead == 1 else "s have"))
+            numEventsWritten = sum(_getNumEvents(dictresult['result'][0]['runsAndLumis'], 'EDM'))
+            self.logger.info("%d event%s been written" % (numEventsWritten, " has" if numEventsWritten == 1 else "s have"))
         else:
             analyzed, diff, doublelumis = BasicJobType.subtractLumis(dictresult['result'][0]['dbsInLumilist'], dictresult['result'][0]['dbsOutLumilist'])
-            self.logger.info("%d files have been processed" % dictresult['result'][0]['dbsNumFiles'])
-            self.logger.info("%d events have been written" % dictresult['result'][0]['dbsNumEvents'])
+            numFilesProcessed = dictresult['result'][0]['dbsNumFiles']
+            self.logger.info("%d file%s been processed" % (numFilesProcessed, " has" if numFilesProcessed == 1 else "s have"))
+            numEventsWritten = dictresult['result'][0]['dbsNumEvents']
+            self.logger.info("%d event%s been written" % (numEventsWritten, " has" if numEventsWritten == 1 else "s have"))
         returndict = {}
         if self.outdir:
             if not os.path.exists(self.outdir):
@@ -79,13 +84,13 @@ class report(SubCommand):
             with open(os.path.join(jsonFileDir, 'lumiSummary.json'), 'w') as jsonFile:
                 json.dump(analyzed, os.path.join(jsonFile))
                 jsonFile.write("\n")
-                self.logger.info("Analyzed lumi written to %s/lumiSummary.json" % jsonFileDir)
+                self.logger.info("Analyzed luminosity sections written to %s/lumiSummary.json" % jsonFileDir)
                 returndict['analyzed'] = analyzed
         if diff:
             with open(os.path.join(jsonFileDir, 'missingLumiSummary.json'), 'w') as jsonFile:
                 json.dump(diff, jsonFile)
                 jsonFile.write("\n")
-                self.logger.info("%sWarning%s: Not Analyzed lumi written to %s/missingLumiSummary.json" % (colors.RED, colors.NORMAL, jsonFileDir))
+                self.logger.info("%sWarning%s: Not analyzed luminosity sections written to %s/missingLumiSummary.json" % (colors.RED, colors.NORMAL, jsonFileDir))
                 returndict['missingLumi']= diff
         if doublelumis:
             with open(os.path.join(jsonFileDir, 'double.json'), 'w') as jsonFile:

--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -139,44 +139,44 @@ class Analysis(BasicJobType):
     def validateConfig(self, config):
         """
         Validate the CMSSW portion of the config file making sure
-        required values are there and optional values don't conflict
+        required values are there and optional values don't conflict.
         """
 
         valid, reason = self.validateBasicConfig(config)
         if not valid:
-            return (valid, reason)
+            return valid, reason
 
         if not getattr(config.Data, 'inputDataset', None) and not getattr(config.Data, 'userInputFile', None):
-            valid = False
-            reason += 'Crab configuration problem: missing or null input dataset name. '
+            msg  = "Invalid CRAB configuration: Analysis job type requires an input dataset (or a set of user input files) to run on."
+            msg += "\nTo specify an input dataset (or a set of user input files) use the parameter Data.inputDataset (or Data.userInputFile)."
+            return False, msg
+
+        if getattr(config.Data, 'primaryDataset', None):
+            msg  = "Invalid CRAB configuration: Analysis job type does not need a primary dataset name to be specified."
+            msg += "\nPlease remove the parameter Data.primaryDataset."
+            return False, msg
 
         if self.splitAlgo == 'EventBased':
-            valid = False
-            reason += 'Analysis JobType does not support EventBased Splitting.'
+            msg  = "Invalid CRAB configuration: Analysis job type does not support event-based splitting."
+            msg += "\nPlease set Data.splitting = 'FileBased' or 'LumiBased'."
+            return False, msg
 
-        return (valid, reason)
+        return True, "Valid configuration"
 
 
     def validateBasicConfig(self, config):
         """
         Validate the common portion of the config for data and MC making sure
-        required values are there and optional values don't conflict
+        required values are there and optional values don't conflict.
         """
-
-        valid = True
-        reason = ''
-
-        if not getattr(config, 'Data', None):
-            valid = False
-            reason += 'Crab configuration problem: missing Data section. '
 
         self.splitAlgo = getattr(config.Data, 'splitting', None)
         if not self.splitAlgo:
-            valid = False
-            reason += 'Crab configuration problem: missing or null splitting algorithm. '
+            msg = "Invalid CRAB configuration: Parameter Data.splitting not specified."
+            return False, msg
 
         if not getattr(config.JobType, 'psetName', None):
-            valid = False
-            reason += 'Crab configuration problem: missing or null CMSSW config file name. '
+            msg = "Invalid CRAB configuration: Parameter JobType.psetName not specified."
+            return False, msg
 
-        return (valid, reason)
+        return True, "Valid configuration"

--- a/src/python/CRABClient/JobType/BasicJobType.py
+++ b/src/python/CRABClient/JobType/BasicJobType.py
@@ -7,6 +7,8 @@ Conventions:
 from ast import literal_eval
 from WMCore.Configuration import Configuration
 from WMCore.DataStructs.LumiList import LumiList
+from CRABClient.client_exceptions import ConfigurationException
+
 
 class BasicJobType(object):
     """
@@ -17,15 +19,16 @@ class BasicJobType(object):
 
     def __init__(self, config, logger, workingdir):
         self.logger = logger
-        ## Before everything checking if the config is ok
+        ## Before everything, check if the config is ok.
         if config:
-            result, msg = self.validateConfig( config )
-            if result:
+            valid, msg = self.validateConfig(config)
+            if valid:
                 self.config  = config
                 self.workdir = workingdir
             else:
-                ## the config was not ok, returning a proper message
-                raise Exception( msg )
+                msg += "\nThe documentation about the CRAB configuration file can be found in"
+                msg += " https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3ConfigurationFile."
+                raise ConfigurationException(msg)
 
 
     def run(self):
@@ -44,7 +47,7 @@ class BasicJobType(object):
         Allows to have a basic validation of the needed parameters
         """
         ## (boolean with the result of the validation, eventual error message)
-        return (True, '')
+        return True, "Valid configuration"
 
 
     @staticmethod
@@ -77,6 +80,7 @@ class BasicJobType(object):
 
         #get the compact list using CMSSW framework
         return mergedLumis.getCompactList(), (LumiList(compactList=lumimask) - mergedLumis).getCompactList(), doubleLumis.getCompactList()
+
 
     @staticmethod
     def subtractLumis(input, output):


### PR DESCRIPTION
Also:
1) Require Data.primaryDataset in PrivateMC.
2) Don't accept Data.primaryDataset in Analisys job type.
3) Move the spellchecking of the configuration parameters from submit::\__call\__ to SubCommand::validateConfig (which if called in SubCommand::\__init\__ when loading the config)
4) Some small changes in messages to user when validating the config and in crab report.