### PR TITLE
crab getoutput fix Broken pipe. Fixes #4221

### DIFF
--- a/src/python/CRABClient/Commands/remote_copy.py
+++ b/src/python/CRABClient/Commands/remote_copy.py
@@ -245,7 +245,6 @@ class remote_copy(SubCommand):
                     except Exception, ex:
                         self.logger.debug("%sWarning%s: Cannot remove the file because of: %s" % (colors.RED, colors.NORMAL, ex))
                 time.sleep(60)
-                return
             else:
                 self.logger.info("%sSuccess%s: Success in retrieving %s " % (colors.GREEN, colors.NORMAL, fileid))
             if not url_input and hasattr(myfile, 'checksum'):


### PR DESCRIPTION
If transfer failing due to :   
   1. Timeout
   2. Wrong size
   3. Failure deletion of file if size is not correct
All these exceptions are catched and reported to user, but also if any exception happens, function returns and subprocess is removed(not getting any new transfer request). When all subprocesses (10 or N which user specified) end up any of this error, we are getting 'Broken Pipe' error. Don`t return until queue still have work to do.