### PR TITLE
Rename basicConfig to config.

### DIFF
--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -17,6 +17,20 @@ from WMCore.Configuration import Configuration
 from CRABClient.ClientExceptions import ClientException, UsernameException, ProxyException
 
 
+def config():
+    """
+    Return a Configuration object containing all the sections that CRAB recognizes.
+    """
+    config = Configuration()
+    config.section_("General")
+    config.section_("JobType")
+    config.section_("Data")
+    config.section_("Site")
+    config.section_("User")
+    config.section_("Debug")
+    return config
+
+
 def getUsernameFromSiteDB():
     """
     Retrieve username from SiteDB by doing a query to
@@ -62,20 +76,6 @@ def getUsernameFromSiteDB():
     if username == 'null':
         username = None
     return username
-
-
-def basicConfig():
-    """
-    Return a Configuration object containing all the sections that CRAB recognizes.
-    """
-    config = Configuration()
-    config.section_("General")
-    config.section_("JobType")
-    config.section_("Data")
-    config.section_("Site")
-    config.section_("User")
-    config.section_("Debug")    
-    return config
 
 
 def getFileFromURL(url, filename = None):


### PR DESCRIPTION
This way the user can do

import CRABClient
config = CRABClient.Config()

as suggested by @belforte in https://github.com/dmwm/CRABServer/issues/4519. 
@belforte Now that we have introduced the module CRABClient.UserUtilities which contains all functions that we expose to users (including Config() -which is still called basicConfig()-), do you still prefer the above for the config, or you prefer to keep Config() inside CRABClient.UserUtilities?

Other question I have also is: If the user wants to use the functions from CRABClient.UserUtilities, how should we tell him/her to use these functions? Two options below:

1) Only import CRABClient and he/she gets everything, but then calling a function from CRABClient.UserUtilities requires to always put CRABClient.UserUtilities:

import CRABClient   <---- That's the only import the user will do.
config = CRABClient.Config()
hello = CRABClient.UserUtilities.func1()
ciao = CRABClient.UserUtilities.func2()

or

2) Use separate imports for the functions in CRABClient.UserUtilities:

import CRABClient
config = CRABClient.Config()
from CRABClient.UserUtilities import func1(), func2()
hello = func1()
ciao = func2()