### PR TITLE
Old 'config' function was named 'getBasicConfig', not 'basicConfig'.

### DIFF
--- a/src/python/CRABClient/client_utilities.py
+++ b/src/python/CRABClient/client_utilities.py
@@ -5,10 +5,13 @@ import logging
 import inspect
 from CRABClient.ClientUtilities import colors
 
-def printModuleRetirementMsg():
+def printModuleRetirementMsg(newname = None):
+    renamemsg = ""
+    if newname:
+        renamemsg = " (with new name '%s')" % (newname)
     curframe = inspect.currentframe()
     calframe = inspect.getouterframes(curframe, 2)
-    msg  = "The method %s is now available in the CRABClient.UserUtilities module." % (calframe[1][3])
+    msg  = "The method %s is now available in the CRABClient.UserUtilities module%s." % (calframe[1][3], renamemsg)
     msg += " From 1 April 2015, loading %s from CRABClient.client_utilities" % (calframe[1][3])
     msg += " will not be possible anymore (CRABClient.client_utilities will be removed)."
     msg += " Please change your code accordingly before 1 April 2015."
@@ -22,10 +25,10 @@ def getUsernameFromSiteDB():
     return getUsernameFromSiteDB_new()
 
 
-def basicConfig():
-    printModuleRetirementMsg()
-    from CRABClient.UserUtilities import basicConfig as basicConfig_new
-    return basicConfig_new()
+def getBasicConfig():
+    printModuleRetirementMsg(newname = "config")
+    from CRABClient.UserUtilities import config as getBasicConfig_new
+    return getBasicConfig_new()
    
 
 def getFileFromURL(url, filename = None):


### PR DESCRIPTION
Test:

I included in my crabConfig_test.py file:

from CRABClient.client_utilities import getBasicConfig
config = getBasicConfig()

$ crab submit -c crabConfig_test.py
Will use configuration file crabConfig_test.py.
Warning: The method getBasicConfig is now available in the CRABClient.UserUtilities module (with new name 'config'). From 1 April 2015, loading getBasicConfig from CRABClient.client_utilities will not be possible anymore (CRABClient.client_utilities will be removed). Please change your code accordingly before 1 April 2015.
