### PR TITLE
Add a 'dryrun' option for crab submit.

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -93,7 +93,8 @@ commandsConfiguration = {
     'resubmit'      : {'requiresREST': True,  'initializeProxy': True,  'requiresTaskOption': True,  'useCache': True },
     'status'        : {'requiresREST': True,  'initializeProxy': True,  'requiresTaskOption': True,  'useCache': True },
     'uploadlog'     : {'requiresREST': True,  'initializeProxy': True,  'requiresTaskOption': False, 'useCache': False},
-    'tasks'         : {'requiresREST': True,  'initializeProxy': True,  'requiresTaskOption': False, 'useCache': False}
+    'tasks'         : {'requiresREST': True,  'initializeProxy': True,  'requiresTaskOption': False, 'useCache': False},
+    'proceed'       : {'requiresREST': True,  'initializeProxy': True,  'requiresTaskOption': True,  'useCache': True}
 }
 
 

--- a/src/python/CRABClient/Commands/proceed.py
+++ b/src/python/CRABClient/Commands/proceed.py
@@ -1,0 +1,42 @@
+from CRABClient.Commands.SubCommand import SubCommand
+from CRABClient.ClientExceptions import RESTCommunicationException
+from CRABClient import __version__
+import CRABClient.Emulator
+
+import urllib
+
+class proceed(SubCommand):
+    """
+    Continue submission of a task which was initialized with 'crab submit --dryrun'
+    """
+
+    def __init__(self, logger, cmdargs=None):
+        SubCommand.__init__(self, logger, cmdargs)
+
+    def __call__(self):
+        serverFactory = CRABClient.Emulator.getEmulator('rest')
+        server = serverFactory(self.serverurl, self.proxyfilename, self.proxyfilename, version = __version__)
+
+        msg = "Continuing submission of task %s" % (self.cachedinfo['RequestName'])
+        self.logger.debug(msg)
+
+        request = {'workflow': self.cachedinfo['RequestName'], 'subresource': 'proceed'}
+
+        self.logger.info("Sending the request to the server")
+        self.logger.debug("Submitting %s " % str(request))
+        result, status, reason = server.post(self.uri, data=urllib.urlencode(request))
+        self.logger.debug("Result: %s" % (result))
+        if status != 200:
+            msg = "Problem continuing task submission:\ninput:%s\noutput:%s\nreason:%s" \
+                  % (str(request), str(result), str(reason))
+            raise RESTCommunicationException(msg)
+        msg = "Task continuation request successfully sent to the CRAB3 server"
+        if result['result'][0]['result'] != 'ok':
+            msg += "\nServer responded with: '%s'" % (result['result'][0]['result'])
+            status = {'status': 'FAILED'}
+        else:
+            status = {'status': 'SUCCESS'}
+            self.logger.info("To check task progress, use 'crab status'")
+        self.logger.info(msg)
+
+        return status

--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -34,7 +34,7 @@ class resubmit(SubCommand):
         msg = "Requesting resubmission for failed jobs in task %s" % (self.cachedinfo['RequestName'])
         self.logger.debug(msg)
 
-        configreq = {'workflow': self.cachedinfo['RequestName']}
+        configreq = {'workflow': self.cachedinfo['RequestName'], 'subresource': 'resubmit'}
         for attr_name in ['jobids', 'sitewhitelist', 'siteblacklist', 'maxjobruntime', 'maxmemory', 'numcores', 'priority']:
             attr_value = getattr(self, attr_name)
             if attr_value:


### PR DESCRIPTION
Example output:

```
Sending the request to the server
Success: Your task has been delivered to the CRAB3 server.
Waiting for task to be processed
Checking task status
Task status: NEW
Please wait...
Task status: UPLOADED

Executing local test run (needed for timing estimates), please wait...
Using LumiBased splitting

Task consists of 301 jobs to process 3009 lumis
The estimated memory requirement is 1306 MB
The longest job will process 10 lumis, with an estimated processing time of 142 minutes
The average job will process 9 lumis, with an estimated processing time of 142 minutes
The shortest job will process 9 lumis, with an estimated processing time of 128 minutes

Dry run requested: task paused
To continue processing, use 'crab proceed'
```