### PR TITLE
crab getlog --short

### DIFF
--- a/src/python/CRABClient/Commands/getlog.py
+++ b/src/python/CRABClient/Commands/getlog.py
@@ -1,9 +1,18 @@
+import os
+import sys
+import urllib
+from httplib import HTTPException
+
+from CRABClient import __version__
+from RESTInteractions import HTTPRequests
+from CRABClient.UserUtilities import getFileFromURL
 from CRABClient.Commands.remote_copy import remote_copy
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.Commands.getcommand import getcommand
-from CRABClient.ClientExceptions import ConfigurationException
+from CRABClient.ClientUtilities import colors
+from CRABClient.ClientExceptions import ConfigurationException, RESTCommunicationException, ClientException
+import CRABClient.Emulator
 
-import os
 
 class getlog(getcommand):
     """
@@ -16,10 +25,53 @@ class getlog(getcommand):
     visible = True #overwrite getcommand
 
     def __call__(self):
-        returndict = getcommand.__call__(self, subresource = 'logs')
-        if not returndict.get('success', {}) and not returndict.get('failed', {}):
-            msg = "This is normal behavior unless General.transferLogs=True is present in the task configuration."
-            self.logger.info(msg)
+        if self.options.short:
+            inputlist = {'subresource': 'webdir', 'workflow': self.cachedinfo['RequestName']}
+            serverFactory = CRABClient.Emulator.getEmulator('rest')
+            server = serverFactory(self.serverurl, self.proxyfilename, self.proxyfilename, version=__version__) 
+            uri = self.getUrl(self.instance, resource = 'task')
+            dictresult, status, reason =  server.get(uri, data = inputlist)
+            self.logger.info('Server result: %s' % dictresult['result'][0])
+            dictresult = self.processServerResult(dictresult)
+            if status != 200:
+                msg = "Problem retrieving information from the server:\ninput:%s\noutput:%s\nreason:%s" % (str(inputlist), str(dictresult), str(reason))
+                raise RESTCommunicationException(msg)
+            self.setDestination()
+            self.logger.info("Setting the destination to %s " % self.dest)
+            self.logger.info("Retrieving...")
+            success = []
+            failed = []        
+            for item in self.options.jobids:
+                jobid = str(item[1])
+                filename = 'job_out.'+jobid+'.0.txt'
+                url = dictresult['result'][0]+'/'+filename
+                try:
+                    getFileFromURL(url, self.dest+'/'+filename)
+                    self.logger.info ('Retrieved %s' % (filename))
+                    success.append(filename)
+                    retry = 1
+                    #To retrieve retried joblog, if there is any.
+                    while urllib.urlopen(dictresult['result'][0]+'/'+'job_out.'+jobid+'.'+str(retry)+'.txt').getcode() == 200:
+                        filename = 'job_out.'+jobid+'.'+str(retry)+'.txt'
+                        url = dictresult['result'][0]+'/'+filename
+                        getFileFromURL(url, self.dest+'/'+filename)
+                        self.logger.info ('Retrieved %s' % (filename))
+                        success.append(filename)
+                        retry = retry + 1
+                except ClientException, ex:
+                    self.logger.debug(str(ex))
+                    failed.append(filename)
+            if failed:
+                msg = "%sError%s: Failed to retrieve the following files: %s" % (colors.RED,colors.NORMAL,failed)
+                self.logger.info(msg)
+            else:
+                self.logger.info("%sSuccess%s: All files successfully retrieved." % (colors.GREEN,colors.NORMAL))
+            returndict = {'success': success, 'failed': failed}
+        else:
+            returndict = getcommand.__call__(self, subresource = 'logs')
+            if not returndict.get('success', {}) and not returndict.get('failed', {}):
+                msg = "This is normal behavior unless General.transferLogs=True is present in the task configuration."
+                self.logger.info(msg)
         return returndict
 
     def setOptions(self):
@@ -37,5 +89,16 @@ class getlog(getcommand):
         self.parser.add_option( '--wait',
                                 dest = 'waittime',
                                 help = 'Increase the sendreceive-timeout in second.',)
+        self.parser.add_option( '--short',
+                                dest = 'short',
+                                default = False,
+                                action = 'store_true',
+                                help = 'Get the short version of the log file. Use with --dir and --jobids.',)
         getcommand.setOptions(self)
 
+
+    def validateOptions(self):
+        getcommand.validateOptions(self)
+        if self.options.short:
+            if self.options.jobids == None:
+                raise MissingOptionException('Please specify the jobs with --jobids to retrieve the short log files')

--- a/src/python/CRABClient/Commands/remote_copy.py
+++ b/src/python/CRABClient/Commands/remote_copy.py
@@ -157,7 +157,7 @@ class remote_copy(SubCommand):
             #self.logger.debug("List of failed file and reason: %s" % failedfiles)
             globalExitcode = -1
         else:
-            self.logger.info("%sSuccess%s: All files successfully retrieve " % (colors.GREEN,colors.NORMAL))
+            self.logger.info("%sSuccess%s: All files successfully retrieved" % (colors.GREEN,colors.NORMAL))
             globalExitcode = 0
 
         return successfiles , failedfiles

--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -113,6 +113,7 @@ def getFileFromURL(url, filename = None):
         filename = os.path.basename(path)
     try:
         socket = urllib.urlopen(url)
+        status = socket.getcode()
         filestr = socket.read()
     except IOError, ioex:
         tblogger = logging.getLogger('CRAB3')
@@ -123,8 +124,10 @@ def getFileFromURL(url, filename = None):
     except Exception, ex:
         tblogger = logging.getLogger('CRAB3')
         tblogger.exception(ex)
-        msg = 'Unexpected error while trying to retrieve file from %s: %s' % (url, ex)
+        msg = "Unexpected error while trying to retrieve file from %s: %s" % (url, ex)
         raise ClientException(msg)
+    if status != 200:
+        raise ClientException("Unable to retieve the file from %s. HTTP status code %s. HTTP content: %s" % (url, status, socket.info()))
     with open(filename, 'w') as f:
         f.write(filestr)
     return filename


### PR DESCRIPTION
Fixes https://github.com/dmwm/CRABServer/issues/4637
User can do 'crab getlog --short -dir <task name> --jobids=<job ids>' to get the short version of the log file.