### PR TITLE
Add LHESource detection and print warning for multiple LHE files.

### DIFF
--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -86,6 +86,19 @@ class CMSSWConfig(object):
         return
 
 
+    def hasLHESource(self):
+        """
+        Returns a tuple containing a bool to indicate usage of an
+        LHESource and an integer for the number of input files.
+        """
+        source = self.fullConfig.process.source
+
+        lhe = str(source.type_()) == 'LHESource'
+        files = len(source.fileNames) if lhe else 0
+
+        return lhe, files
+
+
     def outputFiles(self):
         """
         Returns a tuple of lists of output files. First element is PoolOutput files,

--- a/src/python/CRABClient/JobType/PrivateMC.py
+++ b/src/python/CRABClient/JobType/PrivateMC.py
@@ -8,7 +8,9 @@ import re
 from WMCore.Lexicon import lfnParts
 
 from CRABClient.JobType.Analysis import Analysis
+from CRABClient.JobType.CMSSWConfig import CMSSWConfig
 from CRABClient.ClientMapping import getParamDefaultValue
+from CRABClient.ClientUtilities import colors
 
 
 class PrivateMC(Analysis):
@@ -22,6 +24,18 @@ class PrivateMC(Analysis):
         """
         tarFilename, configArguments, isbchecksum = super(PrivateMC, self).run(*args, **kwargs)
         configArguments['jobtype'] = 'PrivateMC'
+
+        cmsswCfg = CMSSWConfig(config=self.config, logger=self.logger,
+                               userConfig=self.config.JobType.psetName)
+        lhe, nfiles = cmsswCfg.hasLHESource()
+        if lhe:
+            configArguments['generator'] = getattr(self.config.JobType, 'generator', 'lhe')
+            if nfiles > 1:
+                msg = "{0}Warning{1}: Using an LHESource with ".format(colors.RED, colors.NORMAL)
+                msg += "more than one input file may not be supported by the CMSSW version used. "
+                msg += "Consider merging the LHE input files to guarantee complete processing."
+                self.logger.warning(msg)
+
         ## Get the user-specified primary dataset name.
         primaryDataset = getattr(self.config.Data, 'primaryDataset', 'CRAB_PrivateMC')
         # Normalizes "foo/bar" and "/foo/bar" to "/foo/bar"


### PR DESCRIPTION
Addresses part of dmwm/CRABServer#4659.  While a framework fix will solve said issue, at
least warn users that the task may not supported by CMSSW as submitted.

This will make the `generator` parameter in the `JobType` section optional / for advanced use only, as `LHESource`s will be auto-detected.