### PR TITLE
Remove code about old --task option.

### DIFF
--- a/src/python/CRABClient/CRABOptParser.py
+++ b/src/python/CRABClient/CRABOptParser.py
@@ -89,10 +89,6 @@ class CRABCmdOptParser(OptionParser):
                                    dest = "task",
                                    default = None,
                                    help = "Path to the CRAB project directory for which the crab command should be executed.")
-            self.add_option("-t", "--task",
-                                   dest = "oldtask",
-                                   default = None,
-                                   help = "Deprecated option renamed to -d/--dir in CRAB v3.3.12.")
 
         if cmdconf['requiresProxyVOOptions']:
             self.add_option("--voRole",

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -15,7 +15,7 @@ from CRABClient.ClientUtilities import BASEURL, SERVICE_INSTANCES
 from CRABClient.CredentialInteractions import CredentialInteractions
 from CRABClient.ClientUtilities import loadCache, getWorkArea, server_info, createWorkArea
 from CRABClient.ClientMapping import renamedParams, commandsConfiguration, configParametersInfo, getParamDefaultValue
-from CRABClient.ClientExceptions import ConfigurationException, MissingOptionException, EnvironmentException, UnknownOptionException
+from CRABClient.ClientExceptions import ConfigurationException, MissingOptionException, EnvironmentException
 
 from WMCore.Credential.Proxy import Proxy
 from WMCore.Configuration import loadConfigurationFile, Configuration
@@ -528,11 +528,6 @@ class SubCommand(ConfigCommand):
         Validate the command line options of the command.
         Raise a ConfigurationException in case of error; don't do anything if ok.
         """
-
-        if self.cmdconf['requiresTaskOption'] and self.options.oldtask is not None:
-            msg  = "%sError%s:" % (colors.RED, colors.NORMAL)
-            msg += " Please indicate the CRAB project directory with --dir=<project-directory>."
-            raise UnknownOptionException(msg)
 
         if self.cmdconf['requiresTaskOption'] and self.options.task is None:
             if len(self.args) > 1:


### PR DESCRIPTION
A guess nobody at this point will try to use the --task option. Python option parser will anyway give the error:

Usage: crab status [options] [args]

crab: error: no such option: --task