### PR TITLE
Separate COMP and CMSSW envs. Fixes #4300

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -22,9 +22,10 @@ from httplib import HTTPException
 
 from CRABClient.CRABOptParser import CRABOptParser
 from CRABClient import __version__ as client_version
-from CRABClient.ClientUtilities import getAvailCommands, logfilter , uploadlogfile, getLoggers, StopExecution
-from CRABClient.ClientExceptions import ClientException
 from CRABClient.ClientMapping import parametersMapping
+from CRABClient.ClientExceptions import ClientException, FEEDBACKMAIL
+from CRABClient.ClientUtilities import getAvailCommands, logfilter , uploadlogfile, getLoggers, StopExecution, flushMemoryLogger
+
 
 
 class MyNullHandler(logging.Handler):
@@ -74,9 +75,6 @@ class CRABClient(object):
 
             Adapted from Doug Hellmann
             """
-            ## Feedback email address
-            feedbackemail = 'hn-cms-computing-tools@cern.ch'
-
             #adding a file handler
             clientinstance = self
             filehandler = logging.FileHandler(client.logger.logfile)
@@ -84,7 +82,7 @@ class CRABClient(object):
 
             ## This goes to the console.
             logging.getLogger('CRAB3.all').error("ERROR: %s: %s" % (exc_type.__name__, exc_value))
-            logging.getLogger('CRAB3.all').error("\n\tPlease email %s for support with the crab.log file or crab.log URL." % (feedbackemail))
+            logging.getLogger('CRAB3.all').error("\n\tPlease email %s for support with the crab.log file or crab.log URL." % (FEEDBACKMAIL))
             logging.getLogger('CRAB3.all').error("\tClient Version: %s" % client_version)
             ## This goes to the crab log file.
             tbLogger = logging.getLogger('CRAB3')
@@ -97,7 +95,7 @@ class CRABClient(object):
                     logurl = uploadlogfile(tbLogger, clientinstance.cmd.proxyfilename, logfilename = None, \
                                            logpath = str(client.logger.logfile), instance = 'prod')
                     msg  = "\tThe log file %s has been uploaded automatically." % (client.logger.logfile)
-                    msg += "\n\tPlease email the following URL '%s' to %s." % (logurl, feedbackemail)
+                    msg += "\n\tPlease email the following URL '%s' to %s if you need help from Analysis Operations." % (logurl, FEEDBACKMAIL)
                     logging.getLogger('CRAB3.all').error(msg)
                 except Exception:
                     logging.getLogger('CRAB3.all').debug('Failed to upload log file automatically')
@@ -132,7 +130,6 @@ if __name__ == "__main__":
     #  - do not want to expose known exception to the outside
     #  - exceptions thrown in the client should exit and set an approprate
     #    exit code, this is a safety net
-
     exitcode = 1
     client = CRABClient()
     try:
@@ -183,19 +180,9 @@ if __name__ == "__main__":
     except StopExecution:
         exitcode = 0
     finally:
-
         # the command crab --version do not have a logger instance
         if hasattr(client, 'logger'):
-            filehandler = logging.FileHandler(client.logger.logfile)
-            ff = logging.Formatter("%(levelname)s %(asctime)s: \t %(message)s")
-            filehandler.setFormatter(ff)
-            filehandler.setLevel(logging.DEBUG)
-            logging.getLogger('CRAB').addHandler(filehandler)
-
-            client.memhandler.setTarget(filehandler)
-            client.memhandler.flush()
-            client.memhandler.close()
-            client.logger.removeHandler(client.memhandler)
+            flushMemoryLogger(client.logger, client.memhandler)
 
     if hasattr(client, 'cmd'):
         client.cmd.terminate( exitcode )

--- a/bin/crab.sh
+++ b/bin/crab.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+CRAB_SOURCE_SCRIPT="/cvmfs/cms.cern.ch/crab3/crab.sh"
+
+## Determine if this is a submit command
+SUBMIT=false;
+for i in "$@"; do
+    if [ "$i" = "submit" ] || [ "$i" = "sub" ]; then
+        SUBMIT=true;
+    fi
+done
+
+## If it is a submit command run the bootstrap script
+if [ "$SUBMIT" = true ]; then
+    ## Get the bin directory so that we know where the crab3bootstrap is located. The directory will be added to the PATH
+    CRAB3_BIN_ROOT=$(sh -c "source $CRAB_SOURCE_SCRIPT >/dev/null 2>/dev/null; if [ \$? -eq 0 ] && [ -d \$CRABCLIENT_ROOT ]; \
+                        then echo \$CRABCLIENT_ROOT/bin; else exit 1; fi")
+    if [ $? -ne 0 ]; then
+        echo -e "Error while loading CRAB3 environment. Cannot find CRAB3 root direcotry inside:\n\t$CRAB_SOURCE_SCRIPT";
+        exit 1;
+    fi
+
+    ## Get the location of the python packages of the CRAB3 client. We'll add them to the PYTHONPATH before executing the
+    ## bootstrap script. We will only add the python packages, without setting the COMP environment)
+    CRAB3_PY_ROOT=$(sh -c "source $CRAB_SOURCE_SCRIPT >/dev/null 2>/dev/null; if [ \$? -eq 0 ] && [ -d \$CRABCLIENT_ROOT ]; \
+                        then echo \$CRABCLIENT_ROOT/\$PYTHON_LIB_SITE_PACKAGES; else exit 1; fi")
+    if [ $? -ne 0 ]; then
+        echo -e "Error while loading CRAB3 environment. Cannot find CRAB3 root direcotry inside:\n\t$CRAB_SOURCE_SCRIPT";
+        exit 1;
+    fi
+
+    ## Set two temporary variable for PATH and PYTHONPATH. They are going to be expanded BEFORE running the following sh command
+    export PYTHONPATH_TMP=$PYTHONPATH:$CRAB3_PY_ROOT
+    export PATH_TMP=$PATH:$CRAB3_BIN_ROOT
+
+    BOOTSTRAP_OUT=$(sh -c "export PATH=$PATH_TMP:$PATH; export PYTHONPATH=$PYTHONPATH_TMP:$PYTHONPATH; crab3bootstrap "$@"; \
+                                    if [ \$? -ne 0 ]; then exit 1; fi")
+    #if the script does not exit with 0 then the output is the error message.
+    if [ $? -ne 0 ]; then
+        echo "$BOOTSTRAP_OUT"
+        exit 1;
+    fi
+    ## The submit command will know what to do if this variable is set! See TODO: add link to an hypothetical twiki
+    export CRAB3_BOOTSTRAP_DIR=$BOOTSTRAP_OUT
+fi
+
+## Execute the client command in a pure COMP environment
+eval `scram unset -sh`
+source $CRAB_SOURCE_SCRIPT
+
+crab "$@"
+## Remove the temporary direcotry, but only if we run the bootstrap script
+[ -z "$CRAB3_BOOTSTRAP_DIR" ] || rm -rf "$CRAB3_BOOTSTRAP_DIR"

--- a/bin/crab3bootstrap
+++ b/bin/crab3bootstrap
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+""" This utility is used to prepare everything CRAB3 needs from the CMSSW environment.
+    The purpose of this script is to allow to run CRAB3 in a pure COMP environment
+    after running 'scram unset env'
+
+    In particular the script:
+        - saves the environment variables used by CRAB3: SCRAM_ARCH, CMSSW_BASE, CMSSW_RELEASE_BASE, CMSSW_VERSION, LOCALRT
+        - handles the PSet file:
+            * get the output files (tfiles and edmfiles)
+            * dump the pickled expanded version of the pset
+"""
+#TODO check what happens if I run this script when 'CRAB3_BOOTSTRAP_DIR' is set
+import os
+import sys
+import json
+import tempfile
+import traceback
+from optparse import OptionParser
+
+from CRABClient.CRABOptParser import CRABOptParser
+from CRABClient.CRABOptParser import CRABCmdOptParser
+from CRABClient.JobType.CMSSWConfig import CMSSWConfig
+from CRABClient.JobType.ScramEnvironment import ScramEnvironment
+from CRABClient.ClientExceptions import ClientException, ConfigurationException, FEEDBACKMAIL
+from CRABClient.ClientUtilities import BOOTSTRAP_ENVFILE, BOOTSTRAP_INFOFILE, BOOTSTRAP_CFGFILE, setSubmitParserOptions, validateSubmitOptions, getLoggers, flushMemoryLogger
+
+from WMCore.Configuration import loadConfigurationFile
+
+
+def saveScramEnv(destFile, logger):
+    """ Copy the environment variables used by CRAB3 into a json dict, and dump it into 'destFile'
+t
+    """
+    try:
+        c3env = ScramEnvironment(logger)
+        with open(destFile, 'w') as fd:
+            json.dump(c3env, fd)
+    except IOError as ioe:
+        raise ClientException("Cannot save file %s: %s" %  (destFile, ioe))
+
+
+def saveCfgFile(destFile, cmsswCfg):
+    """ Save the pset file pickled and expanded version into 'destFile'
+    """
+    try:
+        cmsswCfg.writeFile(destFile)
+    except IOError as ioe:
+        raise ClientException("Cannot save file %s: %s" %  (destFile, ioe))
+
+
+def saveCfgInfo(destFile, cmsswCfg):
+    """ Get the output files from the pset, LHE info, and dump them into 'destFile'
+    """
+    try:
+        info = {}
+        edmfiles, tfiles = cmsswCfg.outputFiles()
+        lhe, nfiles = cmsswCfg.hasLHESource()
+        info['outfiles'] = [ edmfiles, tfiles]
+        info['lheinfo'] = [lhe, nfiles]
+        with open(destFile, 'w') as fd:
+            json.dump(info, fd)
+    except IOError as ioe:
+        raise ClientException("Cannot save file %s: %s" %  (destFile, ioe))
+
+
+def getTmpDir():
+    """ Create a temporary directory for storing the information the client needs
+    """
+    try:
+        tempName = tempfile.mkdtemp()
+    except Exception as e: #I could not find any documentation about possible failures of mkdtemp. Catching Exception
+        raise ClientException(("Cannot create the temporary directory to store the files created by the bootstrap script."
+                               "Error: %s" % e))
+    return tempName
+
+
+def getConfigName(logger):
+    """ Get the configuration filename from the command line options
+    """
+    ## The client has a "two level" parsing. One global (for example gets the --debug option and the command name),
+    ## and one specialized that depends on the command.
+    parser = CRABOptParser()
+    optParser = CRABCmdOptParser("submit", "", True)
+    setSubmitParserOptions(optParser)
+
+    opt, args =  parser.parse_args()
+    args = args or []
+    opt, cmdargs = optParser.parse_args(args[1:])
+    validateSubmitOptions(opt, args, logger)
+
+    return opt.config
+
+
+def getConfig(cfgName):
+    """ Load the CRAB3 configuration file and get the pset filename
+    """
+    if not os.path.isfile(cfgName):
+        raise ConfigurationException("CRAB configuration file %s not found." % (cfgName))
+    try:
+        config = loadConfigurationFile(os.path.abspath(cfgName))
+    except RuntimeError as re:
+        raise ConfigurationException(("CRAB configuration syntax error: %s"
+                                      "Please refer to https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3CommonErrors#Syntax_error_in_CRAB_configurati" % re ))
+    if getattr(getattr(config, 'JobType', None), 'psetName', None) == None:
+        raise ConfigurationException(("Invalid CRAB configuration %s.\nParameter JobType.psetName not specified..\n"
+                                      "Please, make sure this parameter exists in you CRAB configuration." % (cfgName)))
+
+    return config
+
+
+if __name__ == '__main__':
+    try:
+        logger, memhandler = None, None
+        logger, memhandler = getLoggers(60) #50 is CRITICAL: 60 no logging to the console
+        cfgName = getConfigName(logger)
+        config = getConfig(cfgName)
+        cmsswCfg = CMSSWConfig(config=config, userConfig=config.JobType.psetName, logger=logger)
+        tmpdir = getTmpDir()
+        saveScramEnv( os.path.join(tmpdir, BOOTSTRAP_ENVFILE), logger)
+        saveCfgFile( os.path.join(tmpdir, BOOTSTRAP_CFGFILE), cmsswCfg)
+        saveCfgInfo( os.path.join(tmpdir, BOOTSTRAP_INFOFILE), cmsswCfg)
+    except ClientException as ce:
+        print("Error during CRAB3 bootstrap:\n%s" % str(ce))
+        sys.exit(1)
+    except Exception as e:
+        print("")
+        print("Unknown error during CRAB3 bootstrap.\n%s" % e)
+        print("Please, copy&paste the stacktrace above to the %s list if you need help from Physics Support." % FEEDBACKMAIL)
+        print("")
+        traceback.print_exc()
+        sys.exit(2)
+    finally:
+        if logger and memhandler:
+            flushMemoryLogger(logger, memhandler)
+
+    print(tmpdir)

--- a/doc/FullConfiguration.py
+++ b/doc/FullConfiguration.py
@@ -28,7 +28,7 @@ config.section_("JobType")
 #config.JobType.pluginName  = 'Analysis'
 ## The plugin for MC Private Production
 #config.JobType.pluginName  = 'PrivateMC'
-#config.JobType.psetName    = 'pset.py'
+config.JobType.psetName    = 'pset.py'
 ## Does the job read any additional private file:
 #config.JobType.inputFiles  = ['/tmp/input_file']
 ## Does the job write any output files that need to be collected BESIDES those in output modules or TFileService

--- a/src/python/CRABClient/CRABOptParser.py
+++ b/src/python/CRABClient/CRABOptParser.py
@@ -60,7 +60,7 @@ class CRABOptParser(OptionParser):
 
 class CRABCmdOptParser(OptionParser):
     """ A class that extract the pieces for parsing the command line arguments
-        of the CRAB commands. 
+        of the CRAB commands.
 
     """
 

--- a/src/python/CRABClient/ClientExceptions.py
+++ b/src/python/CRABClient/ClientExceptions.py
@@ -1,3 +1,5 @@
+FEEDBACKMAIL = 'hn-cms-computing-tools@cern.ch'
+
 class ClientException(Exception):
     """
     general client exception

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -49,7 +49,7 @@ class ConfigCommand:
         try:
             self.logger.debug("Loading CRAB configuration file.")
             self.configuration = loadConfigurationFile(os.path.abspath(configname))
-            ## Overwrite configuration parameters passed as arguments in the command line. 
+            ## Overwrite configuration parameters passed as arguments in the command line.
             if overrideargs:
                 for singlearg in overrideargs:
                     if singlearg == configname: continue
@@ -160,7 +160,7 @@ class ConfigCommand:
                         msg += " Maybe you mean %s?" % (SpellChecker.correct(param))
                     return False, msg
 
-        ## Check that each parameter specified in the configuration file is of the 
+        ## Check that each parameter specified in the configuration file is of the
         ## type specified in the configuration map.
         ## Check that, if a parameter is a required one and it has no default value,
         ## then it must be specified in the configuration file.

--- a/src/python/CRABClient/JobType/ScramEnvironment.py
+++ b/src/python/CRABClient/JobType/ScramEnvironment.py
@@ -3,61 +3,103 @@ ScramEnvironment class
 """
 
 import os
+import json
+import logging
 import subprocess
-from CRABClient.ClientExceptions import EnvironmentException
 
-class ScramEnvironment(object):
+from CRABClient.ClientExceptions import EnvironmentException
+from CRABClient.ClientUtilities import BOOTSTRAP_ENVFILE, bootstrapDone
+
+class ScramEnvironment(dict):
 
     """
         _ScramEnvironment_, a class to determine and cache the user's scram environment.
+
+        The class has two modes of work, depending on the existance of the CRAB3_BOOTSTRAP_DIR variable.
+            If it is set loads the environemt from a file inside that deirectory
+            Otherwise take the necessary information directly from the environment
+
+        Raises:
     """
 
 
     def __init__(self, logger=None):
-        self.logger = logger
+        self.logger = logger if logger else logging
 
+        if bootstrapDone():
+            self.logger.debug("Loading required information from the bootstrap environment file")
+            try:
+                self.initFromFile()
+            except EnvironmentException, ee:
+                self.logger.info(str(ee))
+                self.logger.info("Will try to find the necessary information from the environment")
+                self.initFromEnv()
+        else:
+            self.logger.debug("Loading required information from the environment")
+            self.initFromEnv()
+
+        self.logger.debug("Found %s for %s with base %s" % (self.getCmsswVersion(), self.getScramArch(), self.getCmsswBase()))
+
+
+    def initFromFile(self):
+        """ Init the class taking the required information from the boostrap file
+        """
+
+        bootFilename = os.path.join(os.environ['CRAB3_BOOTSTRAP_DIR'], BOOTSTRAP_ENVFILE)
+        if not os.path.isfile(bootFilename):
+            msg = "The CRAB3_BOOTSTRAP_DIR environment variable is set, but I could not find %s" % bootFilename
+            raise EnvironmentException(msg)
+        else:
+            with open(bootFilename) as fd:
+                self.update(json.load(fd))
+
+
+    def initFromEnv(self):
+        """ Init the class taking the required information from the environment
+        """
         self.command = 'scram'
-        self.scramArch = None
+        self["SCRAM_ARCH"] = None
 
         if os.environ.has_key("SCRAM_ARCH"):
-            self.scramArch = os.environ["SCRAM_ARCH"]
+            self["SCRAM_ARCH"] = os.environ["SCRAM_ARCH"]
         else:
+            #I am not sure we should keep this fallback..
             # subprocess.check_output([self.command, 'arch']).strip() # Python 2.7 and later
-            self.scramArch = subprocess.Popen([self.command, 'arch'],
-                                              stdout=subprocess.PIPE)\
-                             .communicate()[0].strip()
+            self["SCRAM_ARCH"] = subprocess.Popen([self.command, 'arch'], stdout=subprocess.PIPE)\
+                                 .communicate()[0].strip()
 
         try:
-            self.cmsswBase        = os.environ["CMSSW_BASE"]
-            self.cmsswReleaseBase = os.environ["CMSSW_RELEASE_BASE"]
-            self.cmsswVersion     = os.environ["CMSSW_VERSION"]
-            self.localRT          = os.environ["LOCALRT"]
-        except KeyError:
-            self.cmsswBase        = None
-            self.cmsswReleaseBase = None
-            self.cmsswVersion     = None
-            self.localRT          = None
-            msg = "Please make sure you have setup the CMS enviroment (cmsenv)."
+            self["CMSSW_BASE"]        = os.environ["CMSSW_BASE"]
+            self["CMSSW_VERSION"]     = os.environ["CMSSW_VERSION"]
+#            Commenting these two out. I don't think they are really needed
+#            self.cmsswReleaseBase = os.environ["CMSSW_RELEASE_BASE"]
+#            self.localRT          = os.environ["LOCALRT"]
+        except KeyError, ke:
+            self["CMSSW_BASE"]        = None
+            self["CMSSW_VERSION"]     = None
+#            self.cmsswReleaseBase = None
+#            self.localRT          = None
+            msg = "Please make sure you have setup the CMS enviroment (cmsenv). Cannot find %s in your env" % str(ke)
             msg += "\nPlease refer to https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookCRAB3Tutorial#CMS_environment for how to setup the CMS enviroment."
             raise EnvironmentException(msg)
-
-        self.logger.debug("Found %s for %s with base %s" % (self.cmsswVersion, self.scramArch, self.cmsswBase))
 
 
     def getCmsswBase(self):
         """
         Determine the CMSSW base (user) directory
         """
-        return self.cmsswBase
+        return self["CMSSW_BASE"]
+
 
     def getCmsswVersion(self):
         """
         Determine the CMSSW version number
         """
-        return self.cmsswVersion
+        return self["CMSSW_VERSION"]
+
 
     def getScramArch(self):
         """
         Determine the scram architecture
         """
-        return self.scramArch
+        return self["SCRAM_ARCH"]


### PR DESCRIPTION
Provides two new scripts:
  crab.sh: wrapper script that does scram unset env before running crab
commands. Also, if the command is a submit run the bootstrap script
  crab3bootstrap: executes all the operations that needs the CMSSW
environment saving the output to a tmp dir. Returns the tmp directory or
the error message in case of errors.

Backward compatibility is guaranteed since the bootstrapDone() function
is called to check if the clients needs to perform the CMSSW related
operations or the bootstrap script was run.

also refactored many parts of the client. We are providin now:
  flushMemoryLogger function that group the code used to save the output messages that
are stored in memory
  validateSubmitOptions to group the code that in the crab submit
command validate the command line options passed by the user
  setSubmitParserOptions to set the command line options of the client
submit command