### PR TITLE
Add setConsoleLogLevel function to control console handler log level. Fixes #4418

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -24,8 +24,7 @@ from CRABClient.CRABOptParser import CRABOptParser
 from CRABClient import __version__ as client_version
 from CRABClient.ClientMapping import parametersMapping
 from CRABClient.ClientExceptions import ClientException, FEEDBACKMAIL
-from CRABClient.ClientUtilities import getAvailCommands, logfilter , uploadlogfile, getLoggers, StopExecution, flushMemoryLogger
-
+from CRABClient.ClientUtilities import getAvailCommands, logfilter , uploadlogfile, initLoggers, setConsoleLogLevelVar, StopExecution, flushMemoryLogger
 
 
 class MyNullHandler(logging.Handler):
@@ -54,14 +53,12 @@ class CRABClient(object):
 
         (options, args) = self.parser.parse_args()
 
-        #the default the logfile destination is /crab.log, it will be  changed  when we have loaded the taskname
-        loglevel = logging.INFO
+        #the default logfile destination is /crab.log, it will be  changed  when we have loaded the taskname
         if options.quiet:
-            loglevel = logging.WARNING
-        if options.debug:
-            loglevel = logging.DEBUG
-        self.logger, self.memhandler = getLoggers(loglevel)
-
+            setConsoleLogLevelVar(logging.WARNING)
+        elif options.debug:
+            setConsoleLogLevelVar(logging.DEBUG)
+        self.logger, self.memhandler = initLoggers()
 
         #Instructions needed in case of early failures: sometimes the traceback logger
         #has not been set yet. The right file handler is only added when the workarea

--- a/bin/crab3bootstrap
+++ b/bin/crab3bootstrap
@@ -23,7 +23,8 @@ from CRABClient.CRABOptParser import CRABCmdOptParser
 from CRABClient.JobType.CMSSWConfig import CMSSWConfig
 from CRABClient.JobType.ScramEnvironment import ScramEnvironment
 from CRABClient.ClientExceptions import ClientException, ConfigurationException, FEEDBACKMAIL
-from CRABClient.ClientUtilities import BOOTSTRAP_ENVFILE, BOOTSTRAP_INFOFILE, BOOTSTRAP_CFGFILE, setSubmitParserOptions, validateSubmitOptions, getLoggers, flushMemoryLogger
+from CRABClient.ClientUtilities import BOOTSTRAP_ENVFILE, BOOTSTRAP_INFOFILE, BOOTSTRAP_CFGFILE, LOGLEVEL_MUTE
+from CRABClient.ClientUtilities import setSubmitParserOptions, validateSubmitOptions, initLoggers, setConsoleLogLevelVar, flushMemoryLogger
 
 from WMCore.Configuration import loadConfigurationFile
 
@@ -111,8 +112,9 @@ def getConfig(cfgName):
 
 if __name__ == '__main__':
     try:
+        setConsoleLogLevelVar(LOGLEVEL_MUTE)
         logger, memhandler = None, None
-        logger, memhandler = getLoggers(60) #50 is CRITICAL: 60 no logging to the console
+        logger, memhandler = initLoggers()
         cfgName = getConfigName(logger)
         config = getConfig(cfgName)
         cmsswCfg = CMSSWConfig(config=config, userConfig=config.JobType.psetName, logger=logger)

--- a/src/python/CRABAPI/RawCommand.py
+++ b/src/python/CRABAPI/RawCommand.py
@@ -4,7 +4,7 @@
 """
 import CRABAPI
 import logging
-from CRABClient.ClientUtilities import getLoggers
+from CRABClient.ClientUtilities import initLoggers
 
 
 # NOTE: Not included in unittests
@@ -29,7 +29,7 @@ def execRaw(command, args):
                   the raw result back from the client. args is a python list,
                   the same python list parsed by the optparse module
     """
-    logger, _ = getLoggers(logging.INFO)
+    logger, _ = initLoggers()
 
     try:
         mod = __import__('CRABClient.Commands.%s' % command, fromlist=command)

--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -21,7 +21,6 @@ from optparse import OptionValueError
 
 ## CRAB dependencies
 import CRABClient.Emulator
-from CRABClient.UserUtilities import getUsernameFromSiteDB
 from CRABClient.ClientExceptions import ClientException, TaskNotFoundException, CachefileNotFoundException, ConfigurationException, ConfigException, UsernameException, ProxyException
 
 
@@ -33,6 +32,7 @@ BOOTSTRAP_ENVFILE = 'crab3env.json'
 BOOTSTRAP_INFOFILE = 'crab3info.json'
 BOOTSTRAP_CFGFILE = 'CMSSW_cfg.py'
 BOOTSTRAP_CFGFILE_PKL = 'CMSSW_cfg.pkl'
+
 
 class colors:
     colordict = {
@@ -59,6 +59,16 @@ class StopExecution():
     """
 
 
+## Dictionary with the client loggers.
+LOGGERS = {}
+
+## The log level for the console handler. Can be overwritten with setConsoleLogLevelVar().
+CONSOLE_LOGLEVEL = logging.INFO
+
+## Log level to mute a logger/handler.
+LOGLEVEL_MUTE = logging.CRITICAL + 10
+
+
 class logfilter(logging.Filter):
     def filter(self, record):
         def removecolor(text):
@@ -76,7 +86,7 @@ class logfilter(logging.Filter):
         return True
 
 
-def getLoggers(loglevel):
+def initLoggers():
     """
     Logging is using the hierarchy system, the CRAB3.all log inherit everything from CRAB3. So everything that is
     logged to CRAB3.all will also go to CRAB3, however thing that logged using CRAB3 will not go to CRAB3.all.
@@ -84,22 +94,21 @@ def getLoggers(loglevel):
 
     CRAB3.all -> screen + file
     CRAB3     -> file
-
-    The loglevel parameter indicates the level for the console handler
     """
+    global LOGGERS
     # Set up the logger and exception handling
     logger = logging.getLogger('CRAB3.all')
     tblogger = logging.getLogger('CRAB3')
     logger.setLevel(logging.DEBUG)
     tblogger.setLevel(logging.DEBUG)
-
     if not logger.handlers:
         # Set up console output to stdout at appropriate level
         console_format = '%(message)s'
         console = logging.StreamHandler(sys.stdout)
         console.setFormatter(logging.Formatter(console_format))
-        console.setLevel(loglevel)
+        console.setLevel(CONSOLE_LOGLEVEL)
         logger.addHandler(console)
+    LOGGERS['CRAB3.all'] = logger
 
     #setting up a temporary memory logging, the flush level is set to 60, the highest logging level is 50 (.CRITICAL)
     #so any reasonable logging level should not cause any sudden flush
@@ -113,10 +122,23 @@ def getLoggers(loglevel):
     filter_ = logfilter()
     memhandler.addFilter(filter_)
     tblogger.addHandler(memhandler)
+    LOGGERS['CRAB3'] = tblogger
 
     logger.logfile = os.path.join(os.getcwd(), 'crab.log')
 
     return logger, memhandler
+
+
+def getLoggers(lvl):
+    msg  = "%sError%s: The function getLoggers(loglevel) from CRABClient.ClientUtilities has been deprecated." % (colors.RED, colors.NORMAL)
+    msg += " Please use the new function setConsoleLogLevel(loglevel) from CRABClient.UserUtilities instead."
+    raise ClientException(msg)
+
+
+def setConsoleLogLevelVar(lvl):
+    global CONSOLE_LOGLEVEL
+    CONSOLE_LOGLEVEL = lvl
+
 
 def flushMemoryLogger(logger, memhandler):
     filehandler = logging.FileHandler(logger.logfile)
@@ -132,14 +154,14 @@ def flushMemoryLogger(logger, memhandler):
 
 
 def getUrl(instance='prod', resource='workflow'):
-        """
-        Retrieve the url depending on the resource we are accessing and the instance.
-        """
-        if instance in SERVICE_INSTANCES.keys():
-            return BASEURL + instance + '/' + resource
-        elif instance == 'private':
-            return BASEURL + 'dev' + '/' + resource
-        raise ConfigurationException('Error: only the following instances can be used: %s' %str(SERVICE_INSTANCES.keys()))
+    """
+    Retrieve the url depending on the resource we are accessing and the instance.
+    """
+    if instance in SERVICE_INSTANCES.keys():
+        return BASEURL + instance + '/' + resource
+    elif instance == 'private':
+        return BASEURL + 'dev' + '/' + resource
+    raise ConfigurationException('Error: only the following instances can be used: %s' %str(SERVICE_INSTANCES.keys()))
 
 
 def uploadlogfile(logger, proxyfilename, logfilename = None, logpath = None, instance = 'prod', serverurl = None, username = None):
@@ -469,6 +491,7 @@ def getUsernameFromSiteDB_wrapped(logger, quiet = False):
     Wrapper function for getUsernameFromSiteDB,
     catching exceptions and printing messages.
     """
+    from CRABClient.UserUtilities import getUsernameFromSiteDB
     username = None
     msg = "Retrieving username from SiteDB..."
     if quiet:

--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -142,3 +142,24 @@ def getFileFromURL(url, filename = None):
         f.write(filestr)
     return filename
 
+
+from CRABClient.ClientUtilities import LOGLEVEL_MUTE
+
+
+def getLoggers():
+    from CRABClient.ClientUtilities import LOGGERS
+    return LOGGERS
+
+
+def getConsoleLogLevel():
+    from CRABClient.ClientUtilities import CONSOLE_LOGLEVEL
+    return CONSOLE_LOGLEVEL
+
+
+def setConsoleLogLevel(lvl):
+    from CRABClient.ClientUtilities import setConsoleLogLevelVar
+    setConsoleLogLevelVar(lvl)
+    if 'CRAB3.all' in logging.getLogger().manager.loggerDict:
+        for h in logging.getLogger('CRAB3.all').handlers:
+            h.setLevel(lvl)
+


### PR DESCRIPTION
A user can do:
from CRABAPI.RawCommand import crabCommand
from CRABClient.UserUtilities import getConsoleLogLevel, setConsoleLogLevel, noLogInfo
origLogLevel = getConsoleLogLevel()
crabCommand(...) # will not be quiet
setConsoleLogLevel(noLogInfo)
crabCommand(...) # will be quiet
crabCommand(...) # will be quiet
setConsoleLogLevel(origLogLevel)
crabCommand(...) # will not be quiet

Are you ok with the name of the constant "noLogInfo"? I was thinking otherwise of something like "LOGLEVEL_MUTE"