### PR TITLE
Remove LHE file warning for appropriate releases.

### DIFF
--- a/src/python/CRABClient/JobType/PrivateMC.py
+++ b/src/python/CRABClient/JobType/PrivateMC.py
@@ -28,7 +28,14 @@ class PrivateMC(Analysis):
         lhe, nfiles = self.cmsswCfg.hasLHESource()
         if lhe:
             configArguments['generator'] = getattr(self.config.JobType, 'generator', 'lhe')
-            if nfiles > 1:
+
+            major, minor, fix = os.environ['CMSSW_VERSION'].split('_')[1:4]
+            warn = True
+            if int(major) >= 7:
+                if int(minor) >= 5:
+                    warn = False
+
+            if nfiles > 1 and warn:
                 msg = "{0}Warning{1}: Using an LHESource with ".format(colors.RED, colors.NORMAL)
                 msg += "more than one input file may not be supported by the CMSSW version used. "
                 msg += "Consider merging the LHE input files to guarantee complete processing."


### PR DESCRIPTION
To track releases, see the following commits:

https://github.com/cms-sw/cmssw/commit/b52beebeb3292e674259df8b4f05c1703f86f374
https://github.com/cms-sw/cmssw/commit/2183765fd615b6402cb80c36f50ef0baa3fb6d92

This does **not** catch pre-releases, which should be run at your own risk,
anyways.

I will add support for releases with the fix added at least as long as this PR is open.  Will eventually fix dmwm/CRABServer#4659