### PR TITLE
Improve crab status output for failed tasks. Consider new task statuses SUBMITFAILED and RESUBMITFAILED in checkStatusLoop.

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -713,7 +713,7 @@ def checkStatusLoop(logger, server, uri, uniquerequestname, targetstatus, cmdnam
             logger.info("Task status: %s" % (dictresult['status']))
             if dictresult['status'] != tmpresult:
                 tmpresult = dictresult['status']
-                if dictresult['status'] == 'FAILED':
+                if dictresult['status'] in ['FAILED', 'SUBMITFAILED', 'RESUBMITFAILED']:
                     continuecheck = False
                     msg  = "%sError%s:" % (colors.RED, colors.NORMAL)
                     msg += " The %s of your task has failed." % ("resubmission" if cmdname == "resubmit" else "submission")
@@ -730,7 +730,7 @@ def checkStatusLoop(logger, server, uri, uniquerequestname, targetstatus, cmdnam
             else:
                 continuecheck = False
                 logger.info("Please check crab.log")
-                logger.debug("Task status other than FAILED, SUBMITTED, UPLOADED, NEW, HOLDING, QUEUED, RESUBMIT")
+                logger.debug("Task status other than FAILED, SUBMITFAILED, RESUBMITFAILED, SUBMITTED, UPLOADED, NEW, HOLDING, QUEUED, RESUBMIT")
             ## Break the loop if we were waiting already too much.
             if currenttime > endtime:
                 continuecheck = False
@@ -745,7 +745,7 @@ def checkStatusLoop(logger, server, uri, uniquerequestname, targetstatus, cmdnam
                 msg  = "%sSuccess%s:" % (colors.GREEN, colors.NORMAL)
                 msg += " Your task has been processed and your jobs have been %s successfully." % ("resubmitted" if cmdname == "resubmit" else "submitted")
                 logger.info(msg)
-            elif currenttime < endtime:
+            elif currenttime < endtime and tmpresult not in ['FAILED', 'SUBMITFAILED', 'RESUBMITFAILED']:
                 msg  = "The CRAB3 server finished processing your task."
                 msg += " Use 'crab status' to see if your jobs have been %s successfully." % ("resubmitted" if cmdname == "resubmit" else "submitted")
                 logger.info(msg)


### PR DESCRIPTION
Requires https://github.com/dmwm/CRABServer/pull/4976