### PR TITLE
Optimize getDoubleLumis function speed

### DIFF
--- a/src/python/CRABClient/JobType/BasicJobType.py
+++ b/src/python/CRABClient/JobType/BasicJobType.py
@@ -83,8 +83,7 @@ class BasicJobType(object):
         #calculate lumis counted twice
         doubleLumis = set()
         for run, lumis in lumisDict.iteritems():
-            for lumi in lumis:
-                if lumisDict[run].count(lumi) > 1:
-                    doubleLumis.add((run,lumi))
+            seen = set()
+            doubleLumis.update(set((run, lumi) for lumi in lumis if (run, lumi) in seen or seen.add((run, lumi))))
         doubleLumis = LumiList(lumis=doubleLumis)
         return doubleLumis.getCompactList()


### PR DESCRIPTION
Hi,

I found this issue when investigating why `crab report` takes ages when ran over a big task (> 100 jobs). In my case, running `crab report` on `DY M-50` took approximately 30 minutes ... Looking at the crab log, I've seen that something fishy occurs between the server response and the first log output:

```
DEBUG 2015-12-02 15:55:34,663:   Result: <...>
INFO 2015-12-02 16:28:23,413:    683 files have been processed
```

I've been able to pinpoint the issue to the function `getDoubleLumis`, which find the duplicated lumi sections. I've changed a bit the code of the function, which lead to a huge gain in runtime. In my test-case, I have only one run (it's MC), and 299900 lumi-sections. Runtimes are:

 - Original code: > 20 mins (I stop the execution)
 - New code: ~ 500ms

It'd be great if this can be merged and available in the next crab3 release!

Thanks,