### PR TITLE
Support options without value in kwargs of crabCommand. Fixes #4577

### DIFF
--- a/src/python/CRABAPI/RawCommand.py
+++ b/src/python/CRABAPI/RawCommand.py
@@ -16,8 +16,12 @@ def crabCommand(command, *args, **kwargs):
     #Converting all arguments to a list. Adding '--' and '='
     arguments = []
     for key, val in kwargs.iteritems():
-        arguments.append('--'+str(key))
-        arguments.append(val)
+        if isinstance(val, bool):
+            if val:
+                arguments.append('--'+str(key))
+        else:
+            arguments.append('--'+str(key))
+            arguments.append(val)
     arguments.extend(list(args))
 
     return execRaw(command, arguments)

--- a/src/python/CRABAPI/RawCommand.py
+++ b/src/python/CRABAPI/RawCommand.py
@@ -3,7 +3,6 @@
         but doesn't want to subprocess.Popen()
 """
 import CRABAPI
-import logging
 
 from CRABClient.ClientUtilities import initLoggers, flushMemoryLogger, removeLoggerHandlers
 


### PR DESCRIPTION
Documentation of the crabCommand API already updated in https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRABClientLibraryAPI