### PR TITLE
Make sure pycurl is always used (WMCore default is httplib)

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -232,7 +232,7 @@ def uploadlogfile(logger, proxyfilename, logfilename = None, logpath = None, ins
     if doupload:
         cacheurl = server_info('backendurls', serverurl, proxyfilename, baseurl)
         cacheurl = cacheurl['cacheSSL']
-        cacheurldict = {'endpoint': cacheurl}
+        cacheurldict = {'endpoint': cacheurl, "pycurl": True}
 
         ufc = UserFileCache(cacheurldict)
         logger.debug("cacheURL: %s\nLog file name: %s" % (cacheurl, logfilename))

--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -20,7 +20,7 @@ class checkwrite(SubCommand):
 
     def __init__(self, logger, cmdargs = None):
         SubCommand.__init__(self, logger, cmdargs)
-        self.phedex = PhEDEx({"cert": self.proxyfilename, "key": self.proxyfilename, "logger": self.logger})
+        self.phedex = PhEDEx({"cert": self.proxyfilename, "key": self.proxyfilename, "logger": self.logger, "pycurl" : True})
         self.lfnsaddprefix = None
         self.filename = None
 
@@ -165,7 +165,7 @@ class checkwrite(SubCommand):
         except HTTPException as errormsg:
             self.logger.info('%sError%s: Failed to contact PhEDEx or wrong PhEDEx node name is used' % (colors.RED, colors.NORMAL))
             self.logger.info('Result: %s\nStatus :%s\nURL :%s' % (errormsg.result, errormsg.status, errormsg.url))
-            raise HTTPException(errormsg)
+            raise
 
         return pfn
 


### PR DESCRIPTION
This is needed if we want to use the lightweight specfile