### PR TITLE
Remove code for backward compatibility with old tasks.

### DIFF
--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -96,8 +96,6 @@ class report(SubCommand):
 
         ## Get the lumis in the input dataset.
         inputDatasetLumis = dictresult['result'][0]['inputDataset']['lumis']
-        if not inputDatasetLumis: # for backward compatibility with tasks submitted before the 3.3.1602 release.
-            inputDatasetLumis = dictresult['result'][0]['dbsInLumilistNewClientOldTask']
         returndict['inputDatasetLumis'] = inputDatasetLumis
 
         ## Get the lumis split across files in the input dataset.


### PR DESCRIPTION
The lines being removed were needed for backward compatibility with tasks submitted before CRAB 3.3.1603 (the release with the new crab report code). After 1 month, I guess you don't care anymore about this backward compatibility.