### PR TITLE
Explicitly test parameter set input configuration for PrivateMC.

### DIFF
--- a/bin/crab3bootstrap
+++ b/bin/crab3bootstrap
@@ -59,8 +59,10 @@ def saveCfgInfo(destFile, cmsswCfg):
         info = {}
         edmfiles, tfiles = cmsswCfg.outputFiles()
         lhe, nfiles = cmsswCfg.hasLHESource()
+        pool = cmsswCfg.hasPoolSource()
         info['outfiles'] = [ edmfiles, tfiles]
         info['lheinfo'] = [lhe, nfiles]
+        info['poolinfo'] = [pool]
         with open(destFile, 'w') as fd:
             json.dump(info, fd)
     except IOError as ioe:

--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -102,6 +102,28 @@ class CMSSWConfig(object):
         return
 
 
+    def hasPoolSource(self):
+        """
+        Returns if an PoolSource is present in the parameter set.
+        """
+        if bootstrapDone():
+            self.logger.debug("Getting source info from bootstrap cachefile.")
+            info = self.getCfgInfo()
+            return info['poolinfo']
+
+        isPool = False
+
+        if getattr(self.fullConfig.process, 'source'):
+            source = self.fullConfig.process.source
+            try:
+                isPool = str(source.type_()) == 'PoolSource'
+            except AttributeError as ex:
+                msg = "Invalid CMSSW configuration: Failed to check if 'process.source' is of type 'PoolSource': %s" % (ex)
+                raise ConfigurationException(msg)
+
+        return isPool
+
+
     def hasLHESource(self):
         """
         Returns a tuple containing a bool to indicate usage of an


### PR DESCRIPTION
We receive a lot of emails with misconfigurations when generating MC.  This
will test the input source of the parameter set and try to point the user
to potential fixes before the task hits the crab server and fails.

Fixes #4610.