### PR TITLE
Deal with outside CL arguments passed to crab_light.sh

### DIFF
--- a/etc/init-light.sh
+++ b/etc/init-light.sh
@@ -16,14 +16,10 @@ CRAB3_PY_ROOT=$(getVariableValue \$CRABCLIENT_ROOT \$PYTHON_LIB_SITE_PACKAGES)
 DBS3_PY_ROOT=$(getVariableValue \$DBS3_CLIENT_ROOT \$PYTHON_LIB_SITE_PACKAGES)
 DBS3_PYCURL_ROOT=$(getVariableValue \$DBS3_PYCURL_CLIENT_ROOT \$PYTHON_LIB_SITE_PACKAGES)
 
-if [ $# -gt 0 ]; then
-    if [ "x$1" == "x-csh" ]; then
-        echo "setenv PYTHONPATH $PYTHONPATH:$CRAB3_PY_ROOT:$DBS3_PY_ROOT:$DBS3_PYCURL_ROOT; \
-                        setenv PATH $PATH:$CRAB3_BIN_ROOT"
-    else
-        exit 254
-    fi
-else
+if [ $# -gt 0 ] && [ "$1" == "-csh" ]; then
+    echo "setenv PYTHONPATH $PYTHONPATH:$CRAB3_PY_ROOT:$DBS3_PY_ROOT:$DBS3_PYCURL_ROOT; \
+                   setenv PATH $PATH:$CRAB3_BIN_ROOT"
+else 
     export PYTHONPATH=$PYTHONPATH:$CRAB3_PY_ROOT:$DBS3_PY_ROOT:$DBS3_PYCURL_ROOT
     export PATH=$PATH:$CRAB3_BIN_ROOT
     if [ -n "$BASH" ]; then


### PR DESCRIPTION
Fixes an issue discovered during validation [*] where external arguments (from user scripts, for example) were being automatically propagated to the crab_light.SH script and confusing it. 
Now, instead of exiting, if the first argument is not "-csh", the script defaults to bash for sourcing the environment. As it was before, if the crab_light.CSH script is used, a "-csh" argument is passed to the .SH script and thus the CSH envronment is sourced.

[*] https://github.com/dmwm/CRABServer/issues/5209#issuecomment-216471062