### PR TITLE
Separate Ops monitoring files into another tarball. Fixes #5153 in CRABServer

### DIFF
--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -61,6 +61,7 @@ class Analysis(BasicJobType):
             self.logger.debug('UNIQUE NAME: tarUUID %s ' % tarUUID)
             if len(tarUUID):
                 tarFilename   = os.path.join(self.workdir, tarUUID + 'default.tgz')
+                debugTarFilename = os.path.join(self.workdir, 'debugFiles.tgz')
                 cfgOutputName = os.path.join(self.workdir, BOOTSTRAP_CFGFILE)
             else:
                 raise EnvironmentException('Problem with uuidgen while preparing for Sandbox upload.')
@@ -139,6 +140,10 @@ class Analysis(BasicJobType):
             msg += " Hence CRAB will not collect any output file from this task."
             self.logger.warning(msg)
 
+        with UserTarball(name=debugTarFilename, logger=self.logger, config=self.config) as dtb:
+            dtb.addMonFiles()
+            debugFilesUploadResult = dtb.upload(filecacheurl = filecacheurl)
+
         ## UserTarball calls ScramEnvironment which can raise EnvironmentException.
         ## Since ScramEnvironment is already called above and the exception is not
         ## handled, we are sure that if we reached this point it will not raise EnvironmentException.
@@ -175,6 +180,7 @@ class Analysis(BasicJobType):
 
         configArguments['cacheurl'] = filecacheurl
         configArguments['cachefilename'] = "%s.tar.gz" % uploadResult
+        configArguments['debugfilename'] = "%s.tar.gz" % debugFilesUploadResult
         self.logger.debug("Result uploading input files: %(cachefilename)s " % configArguments)
 
         # Upload list of user-defined input files to process as the primary input
@@ -227,7 +233,6 @@ class Analysis(BasicJobType):
             configArguments['lumis'] = [str(reduce(lambda x,y: x+y, lumi_mask[run]))[1:-1].replace(' ','') for run in configArguments['runs']]
 
         configArguments['jobtype'] = 'Analysis'
-
         return tarFilename, configArguments
 
 

--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -90,8 +90,20 @@ class UserTarball(object):
             self.tarfile.add(os.path.join(basedir, BOOTSTRAP_CFGFILE_DUMP), arcname=BOOTSTRAP_CFGFILE_DUMP)
 
         #debug directory
-        configtmp = tempfile.NamedTemporaryFile(delete=True)
-        configtmp.write(str(self.config))
+        #configtmp = tempfile.NamedTemporaryFile(delete=True)
+        #configtmp.write(str(self.config))
+        #configtmp.flush()
+        #psetfilename = getattr(self.config.JobType, 'psetName', None)
+        #if not psetfilename == None:
+        #    self.tarfile.add(psetfilename,'/debug/originalPSet.py')
+        #else:
+        #    self.logger.debug('Failed to add pset to tarball')
+        #self.tarfile.add(configtmp.name, '/debug/crabConfig.py')
+        #configtmp.close()
+
+    def addMonFiles(self):
+        configtmp = tempfile.NamedTemporaryFile(delete=True) 
+        configtmp.write(str(self.config)) 
         configtmp.flush()
         psetfilename = getattr(self.config.JobType, 'psetName', None)
         if not psetfilename == None:
@@ -100,7 +112,6 @@ class UserTarball(object):
             self.logger.debug('Failed to add pset to tarball')
         self.tarfile.add(configtmp.name, '/debug/crabConfig.py')
         configtmp.close()
-
 
     def writeContent(self):
         """Save the content of the tarball"""

--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -15,7 +15,7 @@ from CRABClient.JobType.ScramEnvironment import ScramEnvironment
 from CRABClient.ClientUtilities import colors, BOOTSTRAP_CFGFILE, BOOTSTRAP_CFGFILE_PKL
 from CRABClient.ClientExceptions import EnvironmentException, InputFileNotFoundException, CachefileNotFoundException
 
-from ServerUtilities import USER_SANDBOX_EXCLUSIONS, BOOTSTRAP_CFGFILE_DUMP
+from ServerUtilities import NEW_USER_SANDBOX_EXCLUSIONS, BOOTSTRAP_CFGFILE_DUMP
 
 
 class UserTarball(object):
@@ -60,7 +60,7 @@ class UserTarball(object):
 
         # Search for and tar up "data" directories in src/
         srcPath = os.path.join(self.scram.getCmsswBase(), 'src')
-        for root, _dummy, _dummy in os.walk(srcPath):
+        for root, _, _ in os.walk(srcPath):
             if os.path.basename(root) in dataDirs:
                 directory = root.replace(srcPath,'src')
                 self.logger.debug("Adding data directory %s to tarball" % root)
@@ -89,19 +89,10 @@ class UserTarball(object):
             self.tarfile.add(os.path.join(basedir, BOOTSTRAP_CFGFILE_PKL), arcname=BOOTSTRAP_CFGFILE_PKL)
             self.tarfile.add(os.path.join(basedir, BOOTSTRAP_CFGFILE_DUMP), arcname=BOOTSTRAP_CFGFILE_DUMP)
 
-        #debug directory
-        #configtmp = tempfile.NamedTemporaryFile(delete=True)
-        #configtmp.write(str(self.config))
-        #configtmp.flush()
-        #psetfilename = getattr(self.config.JobType, 'psetName', None)
-        #if not psetfilename == None:
-        #    self.tarfile.add(psetfilename,'/debug/originalPSet.py')
-        #else:
-        #    self.logger.debug('Failed to add pset to tarball')
-        #self.tarfile.add(configtmp.name, '/debug/crabConfig.py')
-        #configtmp.close()
-
     def addMonFiles(self):
+        """
+        Add monitoring files the debug tarball.
+        """
         configtmp = tempfile.NamedTemporaryFile(delete=True) 
         configtmp.write(str(self.config)) 
         configtmp.flush()
@@ -109,8 +100,14 @@ class UserTarball(object):
         if not psetfilename == None:
             self.tarfile.add(psetfilename,'/debug/originalPSet.py')
         else:
-            self.logger.debug('Failed to add pset to tarball')
+            self.logger.debug('Failed to add pset to debug_files.tar.gz')
+
         self.tarfile.add(configtmp.name, '/debug/crabConfig.py')
+
+        scriptExe = getattr(self.config.JobType, 'scriptExe', None)
+        if scriptExe:
+            self.tarfile.add(scriptExe, arcname=os.path.basename(scriptExe))
+
         configtmp.close()
 
     def writeContent(self):
@@ -134,7 +131,7 @@ class UserTarball(object):
         archiveName = self.tarfile.name
         self.logger.debug("Uploading archive %s to the CRAB cache. Using URI %s" % (archiveName, filecacheurl))
         ufc = CRABClient.Emulator.getEmulator('ufc')({'endpoint' : filecacheurl, "pycurl": True})
-        result = ufc.upload(archiveName, excludeList = USER_SANDBOX_EXCLUSIONS)
+        result = ufc.upload(archiveName, excludeList = NEW_USER_SANDBOX_EXCLUSIONS)
         if 'hashkey' not in result:
             self.logger.error("Failed to upload source files: %s" % str(result))
             raise CachefileNotFoundException


### PR DESCRIPTION
Issue discussed on crabserver: https://github.com/dmwm/CRABServer/issues/5153

Pull request on crabserver: https://github.com/dmwm/CRABServer/pull/5236