### PR TITLE
Add option to include the external directory in the user tarball

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -67,6 +67,7 @@ parametersMapping = {
                                      {'default': None,       'config': ['Data.runRange'],                   'type': 'StringType',  'required': False},
                                      {'default': None,       'config': ['JobType.psetName'],                'type': 'StringType',  'required': False},
                                      {'default': False,      'config': ['JobType.sendPythonFolder'],        'type': 'BooleanType', 'required': False},
+                                     {'default': False,      'config': ['JobType.sendExternalFolder'],      'type': 'BooleanType', 'required': False},
                                      {'default': None,       'config': ['JobType.pyCfgParams'],             'type': 'ListType',    'required': False},
                                      {'default': False,      'config': ['JobType.disableAutomaticOutputCollection'],'type': 'BooleanType', 'required': False},
                            ]

--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -45,6 +45,14 @@ class UserTarball(object):
         if getattr(self.config.JobType, 'sendPythonFolder', configParametersInfo['JobType.sendPythonFolder']['default']):
             directories.append('python')
             directories.append('cfipython')
+        if getattr(self.config.JobType, 'sendExternalFolder', configParametersInfo['JobType.sendExternalFolder']['default']):
+            externalDirPath = os.path.join(self.scram.getCmsswBase(), 'external')
+            if os.path.exists(externalDirPath) and os.listdir(externalDirPath) != []:
+                directories.append('external')
+            else:
+                self.logger.info("The config.JobType.sendExternalFolder parameter is set to True but the external directory "\
+                                  "doesn't exist or is empty, not adding to tarball. Path: %s" % externalDirPath)
+
         # Note that dataDirs are only looked-for and added under the src/ folder.
         # /data/ subdirs contain data files needed by the code
         # /interface/ subdirs contain C++ header files needed e.g. by ROOT6


### PR DESCRIPTION
Requested by a few users: https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/1972.html. It's possible to work around not having this option by using symlinks, but the code is simple and shouldn't cause any troubles.