### PR TITLE
Old CMSSW compatibility fix - removing unicode

### DIFF
--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -149,7 +149,8 @@ class Analysis(BasicJobType):
             tb.addFiles(userFiles=inputFiles, cfgOutputName=cfgOutputName)
             configArguments['adduserfiles'] = [os.path.basename(f) for f in inputFiles]
             try:
-                uploadResult = tb.upload(filecacheurl = filecacheurl)
+                # convert from unicode to ascii to make it work with CMSSW_5_3_22
+                uploadResult = tb.upload(filecacheurl = filecacheurl.encode('ascii', 'ignore'))
             except HTTPException as hte:
                 if 'X-Error-Info' in hte.headers:
                     reason = hte.headers['X-Error-Info']


### PR DESCRIPTION
Discovered a small problem during validation with the CMSSW_5_3_22 environment [*] having an older pycurl version and not working well with unicode, this should fix it.

[*]
```ERROR 2016-11-07 13:49:19,470:   Impossible to calculate the checksum of the sandbox tarball.
Error message: invalid arguments to setopt.
More details can be found in /afs/cern.ch/user/e/erupeika/crab_projects/crab_1611_test_mon41/crab.log
Traceback (most recent call last):
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/CRABClient/src/python/CRABClient/JobType/Analysis.py", line 152, in run
    uploadResult = tb.upload(filecacheurl = filecacheurl)
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/CRABClient/src/python/CRABClient/JobType/UserTarball.py", line 144, in upload
    result = ufc.upload(archiveName, excludeList = NEW_USER_SANDBOX_EXCLUSIONS)
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/WMCore/src/python/WMCore/Services/UserFileCache/UserFileCache.py", line 150, in upload
    params=params, verb='PUT')
  File "/afs/cern.ch/user/e/erupeika/private/github/repos/WMCore/src/python/WMCore/Services/Requests.py", line 462, in uploadFile
    c.setopt(c.URL, url)
TypeError: invalid arguments to setopt
```