### PR TITLE
Check if returned runsAndLumis dict is empty in report2

### DIFF
--- a/src/python/CRABClient/Commands/report2.py
+++ b/src/python/CRABClient/Commands/report2.py
@@ -311,9 +311,10 @@ class report2(SubCommand):
             jobStatusDict[jobId] = status
 
         # Filter output/input file metadata by finished job state
-        for jobId in jobStatusDict:
-            if jobStatusDict.get(jobId) in ['finished']:
-                reportData['runsAndLumis'][jobId] = dictresult['result'][0]['runsAndLumis'][jobId]
+        if dictresult['result'][0]['runsAndLumis']:
+            for jobId in jobStatusDict:
+                if jobStatusDict.get(jobId) in ['finished']:
+                    reportData['runsAndLumis'][jobId] = dictresult['result'][0]['runsAndLumis'][jobId]
 
         reportData['publication'] = True if getColumn(crabDBInfo, 'tm_publication') == "T" else False
         userWebDirURL = getColumn(crabDBInfo, 'tm_user_webdir')


### PR DESCRIPTION
This dict can be empty and should give the user "Cannot get all the needed information for the report." error in case it is.