### PR TITLE
Fix lumisToProcess.json in report2

### DIFF
--- a/src/python/CRABClient/Commands/report2.py
+++ b/src/python/CRABClient/Commands/report2.py
@@ -350,7 +350,6 @@ class report2(SubCommand):
         Get the lumis to process by each job in the workflow.
         """
         res = {}
-        res['lumisToProcess'] = {}
         if userWebDirURL:
             curl = self.prepareCurl()
             fp = tempfile.NamedTemporaryFile()
@@ -375,7 +374,7 @@ class report2(SubCommand):
                             else:
                                 fd = tarball.extractfile(member)
                                 try:
-                                    res['lumisToProcess'][str(jobid)] = json.load(fd)
+                                    res[str(jobid)] = json.load(fd)
                                 finally:
                                     fd.close()
                     finally:


### PR DESCRIPTION
The resulting dictionary from the method getLumisToProcess() is assigned to the correct reportData key  already in collectReportData() here https://github.com/dmwm/CRABClient/blob/master/src/python/CRABClient/Commands/report2.py#L323. Therefore, with the current behavior, lumisToProcess gets nested twice under the same key 'lumisToProcess'  (reportData['lumisToProcess']['lumisToProcess']) which is incorrect.