### PR TITLE
Don't send additional input files list to server

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -40,7 +40,6 @@ parametersMapping = {
                                                                         'JobType.externalPluginFile'],      'type': 'StringType',  'required': False},
                   'generator'      : {'default': 'pythia',   'config': ['JobType.generator'],               'type': 'StringType',  'required': False},
                   'eventsperlumi'  : {'default': None,       'config': ['JobType.eventsPerLumi'],           'type': 'IntType',     'required': False},
-                  'adduserfiles'   : {'default': [],         'config': ['JobType.inputFiles'],              'type': 'ListType',    'required': False},
                   'addoutputfiles' : {'default': [],         'config': ['JobType.outputFiles'],             'type': 'ListType',    'required': False},
                   'maxjobruntime'  : {'default': 1250,       'config': ['JobType.maxJobRuntimeMin'],        'type': 'IntType',     'required': False},
                   'numcores'       : {'default': 1,          'config': ['JobType.numCores'],                'type': 'IntType',     'required': False},
@@ -70,7 +69,8 @@ parametersMapping = {
                                      {'default': False,      'config': ['JobType.sendPythonFolder'],        'type': 'BooleanType', 'required': False},
                                      {'default': False,      'config': ['JobType.sendExternalFolder'],      'type': 'BooleanType', 'required': False},
                                      {'default': None,       'config': ['JobType.pyCfgParams'],             'type': 'ListType',    'required': False},
-                                     {'default': False,      'config': ['JobType.disableAutomaticOutputCollection'],'type': 'BooleanType', 'required': False}
+                                     {'default': False,      'config': ['JobType.disableAutomaticOutputCollection'],'type': 'BooleanType', 'required': False},
+                                     {'default': [],         'config': ['JobType.inputFiles'],              'type': 'ListType',    'required': False}
                            ]
 }
 

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -116,7 +116,7 @@ class submit(SubCommand):
         self.logger.info("Sending the request to the server")
         self.logger.debug("Submitting %s " % str(self.configreq))
         ## TODO: this shouldn't be hard-coded.
-        listParams = ['adduserfiles', 'addoutputfiles', 'sitewhitelist', 'siteblacklist', 'blockwhitelist', 'blockblacklist', \
+        listParams = ['addoutputfiles', 'sitewhitelist', 'siteblacklist', 'blockwhitelist', 'blockblacklist', \
                       'tfileoutfiles', 'edmoutfiles', 'runs', 'lumis', 'userfiles', 'scriptargs', 'extrajdl']
         self.configreq_encoded = self._encodeRequest(self.configreq, listParams)
         self.logger.debug('Encoded submit request: %s' % (self.configreq_encoded))

--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -40,7 +40,6 @@ class Analysis(BasicJobType):
         Override run() for JobType
         """
         configArguments = {'addoutputfiles'            : [],
-                           'adduserfiles'              : [],
                            'tfileoutfiles'             : [],
                            'edmoutfiles'               : [],
                           }
@@ -147,7 +146,6 @@ class Analysis(BasicJobType):
         with UserTarball(name=tarFilename, logger=self.logger, config=self.config) as tb:
             inputFiles = [re.sub(r'^file:', '', file) for file in getattr(self.config.JobType, 'inputFiles', [])]
             tb.addFiles(userFiles=inputFiles, cfgOutputName=cfgOutputName)
-            configArguments['adduserfiles'] = [os.path.basename(f) for f in inputFiles]
             try:
                 # convert from unicode to ascii to make it work with older pycurl versions
                 uploadResult = tb.upload(filecacheurl = filecacheurl.encode('ascii', 'ignore'))


### PR DESCRIPTION
Issue on CRABServer: https://github.com/dmwm/CRABServer/issues/5321.
Since there's no real need to store this list in the database, I'm removing it. The client simply won't send this parameter to the server anymore and the server will default the value to an empty list.

This is the first step, the next one is to remove this parameter from the server and the database. The second step should be done in a different release so that we don't end up with outdated clients after the deployment sending a value to the server which is no longer expected.