### PR TITLE
Minor bugfix when printing CRAB help message

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -141,7 +141,7 @@ class CRABClient(object):
             sub_cmd = next( v for k,v in self.subCommands.items() if args[0] in v.shortnames or args[0]==v.name)
         except StopIteration:
             print("'" + str(args[0]) + "' is not a valid command.")
-            print(self.parser.print_help())
+            self.parser.print_help()
             sys.exit(-1)
         self.cmd = sub_cmd(self.logger, args[1:])
 


### PR DESCRIPTION
There's no need for this print because the optparse already writes to stdout. The print invokes the method but also prints the return value of the method, which is `None`, so it appears in the output as well.
```
(Pdb) print(self.parser.print_help()) 
Usage: crab [options] COMMAND [command-options] [args]

Options:
  --version   show program's version number and exit
  -h, --help  show this help message and exit
  --quiet     don't print any messages to stdout
  --debug     print extra messages to stdout

Valid commands are: 
  checkusername
  checkwrite (chk)
  getlog (log)
  getlog2 (log2)
  getoutput (output) (out)
  getoutput2 (output2) (out2)
  kill
  proceed
  purge
  remake (rmk)
  report (rep)
  report2 (rep2)
  resubmit
  resubmit2
  status (st)
  status2 (st2)
  submit (sub)
  tasks
  uploadlog (uplog)
To get single command help run:
  crab command --help|-h

For more information on how to run CRAB-3 please follow this link:
https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookCRAB3Tutorial
None

```