### PR TITLE
Provide a default time for Automatic splitting.

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -28,7 +28,7 @@ parametersMapping = {
                   'secondarydata'  : {'default': None,       'config': ['Data.secondaryInputDataset'],      'type': 'StringType',  'required': False},
                   'ignorelocality' : {'default': False,      'config': ['Data.ignoreLocality'],             'type': 'BooleanType', 'required': False},
                   'splitalgo'      : {'default': None,       'config': ['Data.splitting'],                  'type': 'StringType',  'required': True },
-                  'algoargs'       : {'default': None,       'config': ['Data.unitsPerJob'],                'type': 'IntType',     'required': True },
+                  'algoargs'       : {'default': 8 * 60**2,  'config': ['Data.unitsPerJob'],                'type': 'IntType',     'required': False },
                   'totalunits'     : {'default': 0,          'config': ['Data.totalUnits'],                 'type': 'IntType',     'required': False},
                   'lfn'            : {'default': None,       'config': ['Data.outLFNDirBase'],              'type': 'StringType',  'required': False},
                   'publication'    : {'default': True,       'config': ['Data.publication'],                'type': 'BooleanType', 'required': False},

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -197,6 +197,10 @@ class submit(SubCommand):
             except ValueError:
                 msg = "Invalid CRAB configuration: Parameter Data.unitsPerJob must be a valid number, not %s." % (self.configuration.Data.unitsPerJob)
                 return False, msg
+        elif getattr(self.configuration.Data, 'splitting', 'invalid') != 'Automatic':
+            # The default value is only valid for automatic splitting!
+            msg = "Invalid CRAB configuration: Parameter Data.unitsPerJob is missing."
+            return False, msg
 
         ## Check that JobType.pluginName and JobType.externalPluginFile are not both specified.
         if hasattr(self.configuration.JobType, 'pluginName') and hasattr(self.configuration.JobType, 'externalPluginFile'):


### PR DESCRIPTION
Move the error message to the configuration validation for all other
splitting modes.