### PR TITLE
Use proxied webdir for file downloads in new commands

### DIFF
--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -221,9 +221,9 @@ def getMutedStatusInfo(logger):
     cmdobj = getattr(mod, 'status')(logger)
     loglevel = getConsoleLogLevel()
     setConsoleLogLevel(LOGLEVEL_MUTE)
-    crabDBInfo, shortResult = cmdobj.__call__()
+    statusDict, shortResult = cmdobj.__call__()
     setConsoleLogLevel(loglevel)
-    return crabDBInfo, shortResult
+    return statusDict, shortResult
 
 def getColumn(dictresult, columnName):
     columnIndex = dictresult['desc']['columns'].index(columnName)


### PR DESCRIPTION
Not exactly well tested but should work. I had to refactor some other code, in crab report I now use getFileFromUrl instead of constructing a pycurl request because I think it makes it easier to pass the user's proxy with the request.