### PR TITLE
Add limit on number of files for getoutput/getlog

### DIFF
--- a/src/python/CRABClient/Commands/getcommand.py
+++ b/src/python/CRABClient/Commands/getcommand.py
@@ -171,6 +171,12 @@ class getcommand(SubCommand):
             for jobid in possibleJobIds:
                 self.options.jobids.append(('jobids', jobid))
 
+        if len(self.options.jobids) > 500:
+            msg = "You requested to process files for %d jobs." % len(self.options.jobids)
+            msg += "\nThe limit is 500. Please use the '--jobids'"
+            msg += "option to select up to 500 jobs."
+            raise ConfigurationException(msg)
+
         self.transferringIds = transferringIds
 
     def insertPfns(self, fileInfoList):


### PR DESCRIPTION
There was an issue reported by the user about the new `getoutput` command not working [1] (server responds with an error, URI too long). This happened because the GET request, which the client send to the server to retrieve file metadata, was too long. In the GET request, each jobid which the user is wants is specified. This means that if there are 1000 jobs for which we can retrieve the output, the request will have 1000 separate jobids parameters, looking something like this [2].

The request size was not an obvious problem with the old commands because by default the client was not sending the full list of jobids to be processed. However, `crab getoutputold --jobids='1-1000'` will most certainly fail with the same error because in this case the client sends the jobids to the server with the request. While chatting with Stefano I thought about not sending the jobids at all and simply getting metadata for all files in a task from the server, however I suppose that could also be quite costly and the current solution is better.

Now I added an error message when the file number that the user wants to retrieve exceeds 500. Let me know if the message makes sense, also I can change the number of course but I think 500 is reasonable.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/2847.html
[2] ```workflow=170428_112049%3Aanigamov_crab_Bfinder_Jpsipipi_v2_2012A&subresource=data2&limit=1&jobids=1&jobids=2&jobids=3&jobids=4&jobids=5&jobids=6&jobids=7&jobids=8...```
