### PR TITLE
Further API fixes

### DIFF
--- a/src/python/CRABClient/Commands/getcommand.py
+++ b/src/python/CRABClient/Commands/getcommand.py
@@ -157,11 +157,11 @@ class getcommand(SubCommand):
         Also store some information which is used later when deciding the correct pfn.
         """
         statusDict = getMutedStatusInfo(self.logger)
-        if 'jobList' not in statusDict['shortResult']:
+        jobList = statusDict['jobList']
+        if not jobList:
             msg = "Cannot retrieve job list from the status command."
             raise ClientException(msg)
 
-        jobList = statusDict['shortResult']['jobList']
         transferringIds = [x[1] for x in jobList if x[0] in ['transferring', 'cooloff', 'held']]
         finishedIds = [x[1] for x in jobList if x[0] in ['finished', 'failed', 'transferred']]
         possibleJobIds = transferringIds + finishedIds

--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -8,7 +8,6 @@ import tarfile
 import CRABClient.Emulator
 
 from ast import literal_eval
-from cStringIO import StringIO
 
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.Services.DBS.DBSReader import DBSReader
@@ -17,8 +16,7 @@ from CRABClient import __version__
 from CRABClient.ClientUtilities import colors, LOGGERS
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.JobType.BasicJobType import BasicJobType
-from CRABClient.UserUtilities import getMutedStatusInfo, getDataFromURL,\
-    getFileFromURL
+from CRABClient.UserUtilities import getMutedStatusInfo, getFileFromURL
 from CRABClient.ClientExceptions import ConfigurationException, \
     UnknownOptionException, ClientException
 
@@ -294,14 +292,13 @@ class report(SubCommand):
         self.logger.info("Running crab status first to fetch necessary information.")
         # Get job statuses
         statusDict = getMutedStatusInfo(self.logger)
-        shortResult = statusDict['shortResult']
 
-        if not shortResult:
+        if not statusDict['jobList']:
             # No point in continuing if the job list is empty.
             # Can happen when the task is very new / old and the files necessary for status2
             # are unavailable.
             return None
-        reportData['jobList'] = shortResult['jobList']
+        reportData['jobList'] = statusDict['jobList']
 
         reportData['runsAndLumis'] = {}
 
@@ -318,7 +315,7 @@ class report(SubCommand):
 
         reportData['publication'] = statusDict['publicationEnabled']
         userWebDirURL = statusDict['proxiedWebDir']
-        numJobs = len(shortResult['jobList'])
+        numJobs = len(statusDict['jobList'])
 
         reportData['lumisToProcess'] = self.getLumisToProcess(userWebDirURL, numJobs, self.cachedinfo['RequestName'])
         reportData['inputDataset'] = statusDict['inputDataset']

--- a/src/python/CRABClient/Commands/reportold.py
+++ b/src/python/CRABClient/Commands/reportold.py
@@ -265,7 +265,7 @@ class reportold(SubCommand):
                 json.dump(lumisToProcess, jsonFile)
                 jsonFile.write("\n")
                 self.logger.info("  Lumis to process written to lumisToProcess.json")
-            
+
         return returndict
 
 

--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -33,7 +33,7 @@ class resubmit(SubCommand):
         server = serverFactory(self.serverurl, self.proxyfilename, self.proxyfilename, version = __version__)
 
         statusDict = getMutedStatusInfo(self.logger)
-        jobList = statusDict['shortResult']
+        jobList = statusDict['jobList']
 
         if not jobList:
             msg  = "%sError%s:" % (colors.RED, colors.NORMAL)
@@ -43,7 +43,7 @@ class resubmit(SubCommand):
             return None
 
         publicationEnabled = statusDict['publicationEnabled']
-        jobsPerStatus = jobList['jobsPerStatus']
+        jobsPerStatus = statusDict['jobsPerStatus']
 
         if self.options.publication:
             if not publicationEnabled:
@@ -117,14 +117,14 @@ class resubmit(SubCommand):
 
         # Build a dictionary from the jobList
         jobStatusDict = {}
-        for jobStatus, jobId in jobList['jobList']:
+        for jobStatus, jobId in jobList:
             jobStatusDict[jobId] = jobStatus
 
         failedJobStatus = 'failed'
         finishedJobStatus = 'finished'
 
         possibleToResubmitJobIds = []
-        for jobStatus, jobId in jobList['jobList']:
+        for jobStatus, jobId in jobList:
             if (self.options.force and jobStatus == finishedJobStatus) or jobStatus == failedJobStatus:
                 possibleToResubmitJobIds.append(jobId)
 

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -170,17 +170,10 @@ class status(SubCommand):
         statusDict['statusFailureMsg'] = statusFailureMsg
         statusDict['proxiedWebDir'] = proxiedWebDir
         statusDict['jobsPerStatus'] = shortResult.get('jobsPerStatus', {})
+        statusDict['jobList'] = shortResult.get('jobList', {})
         statusDict['publication'] = pubStatus.get('status', {})
         statusDict['publicationFailures'] = pubStatus.get('failure_reasons', {})
-
-        jobs = {}
-        if statusCacheInfo:
-            for jobid, status in statusCacheInfo.items():
-                jobs[jobid] = {'State': status['State']}
-                if status['State'] == 'failed' and 'Error' in status:
-                    jobs[jobid]['Error'] = status['Error']
-        statusDict['jobs'] = jobs
-        statusDict['shortResult'] = shortResult
+        statusDict['jobs'] = statusCacheInfo
         return statusDict
 
     def _percentageString(self, state, value, total):


### PR DESCRIPTION
Some general refactoring and additions of missing things to the API.
- I've gotten rid of the shortResult key in the status return dict because it's redundant.
- jobList in the status return dict should be taken directly from the caching results, I've previously written a loop to generate it but that was a mistake. 
- jobList will now always look like the one returned by `crab statusold --long` (It will have extra things like TotalUserCpuTimeHistory, SiteHistory, etc in addition to the state of each job). The jobList returned by `crab statusold` contains a subset of information of the `crab statusold --long` information AFAICT. It makes no sense for them to be different with the new commands since it costs us nothing to add the information regardless if the status is `--long` or not.