### PR TITLE
Convert webdir to string to avoid problems in pycurl

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -7,6 +7,7 @@ import os
 import re
 import copy
 import datetime
+import logging
 import logging.handlers
 import time
 import pkgutil

--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -156,9 +156,13 @@ def getDataFromURL(url, proxyfilename = None):
     Returns binary data encoded as a string, which can be later processed
     according to what kind of content it represents.
     """
+
+    # Get rid of unicode which may cause problems in pycurl
+    stringUrl = url.encode('ascii')
+
     reqHandler = RequestHandler()
     try:
-        _, data = reqHandler.request(url=url, params={}, ckey=proxyfilename,
+        _, data = reqHandler.request(url=stringUrl, params={}, ckey=proxyfilename,
                 cert=proxyfilename, capath=HTTPRequests.getCACertPath())
     except HTTPException as ex:
         raise ClientException(ex)


### PR DESCRIPTION
The client is again having issues with pycurl and unicode. I wasn't able to quickly determine which CMSSW/pycurl version combinations cause issues but I reproduced the problem with CMSSW_7_4_7 version and this patch should fix it. The error message in the client is this [1], I had seen the same issue before multiple times on the server as well.

[1]
`ERROR: TypeError: invalid arguments to setopt`