### PR TITLE
Make resubmission and status work with new automatic splitting conventions

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -577,17 +577,36 @@ def validURL(serverurl, attrtohave = ['scheme', 'netloc', 'hostname'], attrtonot
     return True
 
 
-def validateJobids(jobids):
+def compareJobids(a, b):
+    """ Compare two job IDs.  Probe jobs (0-*) come first, then processing
+        jobs (>1), then tail jobs (>1-*).
+    """
+    aa = [int(x) for x in a.split('-')]
+    bb = [int(x) for x in b.split('-')]
+    if len(aa) < len(bb):
+        if bb[0] == 0:
+            return 1
+        return -1
+    elif len(aa) > len(bb):
+        if aa[0] == 0:
+            return -1
+        return 1
+    elif aa[0] == bb[0]:
+        return cmp(aa[1], bb[1])
+    return cmp(aa[0], bb[0])
+
+
+def validateJobids(jobids, allowLists=True):
     #check the format of jobids
     if re.match('^\d+((?!(-\d+-))(\,|\-)\d+)*$', jobids):
         jobid = []
         element = jobids.split(',')
         for number in element:
-            if '-' in number:
+            if '-' in number and allowLists:
                 sub = number.split('-')
                 jobid.extend(range(int(sub[0]), int(sub[1])+1))
             else:
-                jobid.append(int(number))
+                jobid.append(int(number) if allowLists else number)
         #removing duplicate and sort the list
         jobid = list(set(jobid))
         return [('jobids', job) for job in jobid]

--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -130,6 +130,11 @@ class resubmit(SubCommand):
 
         allowedJobStates = [failedJobStatus]
         if self.jobids:
+            # Automatic splitting does not work with lists... probe- and
+            # tail-job ids have a '-' in them, so re-split the joblist.
+            if any(('-' in jobId for _, jobId in jobList)):
+                jobidstuple = validateJobids(self.options.jobids, False)
+                self.jobids = [str(jobid) for (_, jobid) in jobidstuple]
             msg = "Requesting resubmission of jobs %s in task %s" % (self.jobids, self.cachedinfo['RequestName'])
             self.logger.debug(msg)
             if self.options.force:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -11,7 +11,7 @@ from httplib import HTTPException
 
 import CRABClient.Emulator
 from CRABClient import __version__
-from CRABClient.ClientUtilities import colors, validateJobids
+from CRABClient.ClientUtilities import colors, validateJobids, compareJobids
 from CRABClient.UserUtilities import getDataFromURL, getColumn
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.ClientExceptions import ConfigurationException
@@ -555,7 +555,7 @@ class status(SubCommand):
             ## of job ids, and that each job id is a string.
             for ec in ec_jobids.keys():
                 for i in range(len(ec_jobids[ec])):
-                    ec_jobids[ec][i] = [str(y) for y in sorted([int(x) for x in ec_jobids[ec][i]])]
+                    ec_jobids[ec][i] = [str(y) for y in sorted([x for x in ec_jobids[ec][i]], cmp=compareJobids)]
             ## Error summary header.
             msg = "\nError Summary:"
             if not self.options.verboseErrors:
@@ -698,7 +698,7 @@ class status(SubCommand):
                     esignvalue = 'Unknown'
                 else:
                     esignvalue = str(value)
-                jobids = [str(jobid) for jobid in sorted([int(jobid) for jobid in valuedict[value]])]
+                jobids = sorted(valuedict[value], cmp=compareJobids)
                 msg += "\n%-20s %-s" % (esignvalue, ", ".join(jobids))
             self.logger.info(msg)
         elif sortby in ['state' , 'site']:


### PR DESCRIPTION
This will remove job id lists for resubmission if automatic splitting is detected - the nomenclatures clash.