### PR TITLE
Make kill final for automatic splitting.

### DIFF
--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -35,6 +35,12 @@ class resubmit(SubCommand):
         statusDict = getMutedStatusInfo(self.logger)
         jobList = statusDict['jobList']
 
+        if getattr(self.cachedinfo['OriginalConfig'].Data, 'splitting', 'Automatic') == 'Automatic' and statusDict['dbStatus'] == 'KILLED':
+            msg  = "%sError%s:" % (colors.RED, colors.NORMAL)
+            msg += " Tasks using automatic splitting cannot be resubmitted after a kill."
+            self.logger.info(msg)
+            return None
+
         if not jobList:
             msg  = "%sError%s:" % (colors.RED, colors.NORMAL)
             msg += " Status information is unavailable, will not proceed with the resubmission."


### PR DESCRIPTION
Companion to dmwm/CRABServer#5644 - this will give a more direct message about being unable to resubmit killed tasks with automatic splitting.