### PR TITLE
Status issues

### DIFF
--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -465,14 +465,14 @@ class status(SubCommand):
         if mem_cnt or run_cnt:
             # Print a summary with memory/cpu usage.
             hint = " and/or improve the jobs splitting (e.g. config.Data.splitting = 'Automatic') in a new task"
-            usage = {'memory':[mem_max,maxMemory,0.7,parametersMapping['on-server']['maxmemory']['default'],'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,parametersMapping['on-server']['maxjobruntime']['default'],'min']}
+            usage = {'memory':[mem_max,maxMemory,0.7,parametersMapping['on-server']['maxmemory']['default'],'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,0,'min']}
             for param, values in usage.items():
                 if values[1] > values[3]:
                     if values[0] < values[2]*values[1]:
                         self.logger.info("\n%sWarning%s: the max jobs %s is less than %d%% of the task requested value (%d %s), please consider to request a lower value (allowed through crab resubmit)%s." % (colors.RED, colors.NORMAL, param, values[2]*100, values[1], values[4], hint))
             if run_sum:
                 cpu_ave = (cpu_sum / run_sum)
-                cpu_thr = 0.7
+                cpu_thr = 0.5
                 if cpu_ave < cpu_thr:
                     self.logger.info("\n%sWarning%s: the average jobs CPU efficiency is less than %d%%, please consider to request a lower number of threads%s." % (colors.RED, colors.NORMAL, cpu_thr*100, hint))
 

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -465,10 +465,11 @@ class status(SubCommand):
         if mem_cnt or run_cnt:
             # Print a summary with memory/cpu usage.
             hint = " and/or improve the jobs splitting (e.g. config.Data.splitting = 'Automatic') in a new task"
-            usage = {'memory':[mem_max,maxMemory,0.7,'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,'min']}
+            usage = {'memory':[mem_max,maxMemory,0.7,parametersMapping['on-server']['maxmemory']['default'],'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,maxJobRuntime=parametersMapping['on-server']['maxjobruntime']['default'],'min']}
             for param, values in usage.items():
-                if values[0] < values[2]*values[1]:
-                    self.logger.info("\n%sWarning%s: the max jobs %s is less than %d%% of the task requested value (%d %s), please consider to request a lower value (allowed through crab resubmit)%s." % (colors.RED, colors.NORMAL, param, values[2]*100, values[1], values[3], hint))
+                if values[1] > values[3]:
+                    if values[0] < values[2]*values[1]:
+                        self.logger.info("\n%sWarning%s: the max jobs %s is less than %d%% of the task requested value (%d %s), please consider to request a lower value (allowed through crab resubmit)%s." % (colors.RED, colors.NORMAL, param, values[2]*100, values[1], values[4], hint))
             if run_sum:
                 cpu_ave = (cpu_sum / run_sum)
                 cpu_thr = 0.7

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -465,7 +465,7 @@ class status(SubCommand):
         if mem_cnt or run_cnt:
             # Print a summary with memory/cpu usage.
             hint = " and/or improve the jobs splitting (e.g. config.Data.splitting = 'Automatic') in a new task"
-            usage = {'memory':[mem_max,maxMemory,0.7,parametersMapping['on-server']['maxmemory']['default'],'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,maxJobRuntime=parametersMapping['on-server']['maxjobruntime']['default'],'min']}
+            usage = {'memory':[mem_max,maxMemory,0.7,parametersMapping['on-server']['maxmemory']['default'],'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,parametersMapping['on-server']['maxjobruntime']['default'],'min']}
             for param, values in usage.items():
                 if values[1] > values[3]:
                     if values[0] < values[2]*values[1]:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -464,17 +464,21 @@ class status(SubCommand):
 
         if mem_cnt or run_cnt:
             # Print a summary with memory/cpu usage.
-            hint = " and/or improve the jobs splitting (e.g. config.Data.splitting = 'Automatic') in a new task"
+            hint = "improve the jobs splitting (e.g. config.Data.splitting = 'Automatic') in a new task"
             usage = {'memory':[mem_max,maxMemory,0.7,parametersMapping['on-server']['maxmemory']['default'],'MB'], 'runtime':[to_hms(run_max),maxJobRuntime,0.3,0,'min']}
             for param, values in usage.items():
                 if values[1] > values[3]:
                     if values[0] < values[2]*values[1]:
-                        self.logger.info("\n%sWarning%s: the max jobs %s is less than %d%% of the task requested value (%d %s), please consider to request a lower value (allowed through crab resubmit)%s." % (colors.RED, colors.NORMAL, param, values[2]*100, values[1], values[4], hint))
+                        self.logger.info("\n%sWarning%s: the max jobs %s is less than %d%% of the task requested value (%d %s), please consider to request a lower value (allowed through crab resubmit) and/or %s." % (colors.RED, colors.NORMAL, param, values[2]*100, values[1], values[4], hint))
             if run_sum:
                 cpu_ave = (cpu_sum / run_sum)
                 cpu_thr = 0.5
+		cpu_thr_multiThread = 0.3
                 if cpu_ave < cpu_thr:
-                    self.logger.info("\n%sWarning%s: the average jobs CPU efficiency is less than %d%%, please consider to request a lower number of threads%s." % (colors.RED, colors.NORMAL, cpu_thr*100, hint))
+                    cpuMsg = "\n%sWarning%s: the average jobs CPU efficiency is less than %d%%, please consider to " % (colors.RED, colors.NORMAL, cpu_thr*100)
+		    if numCores > 1 and cpu_ave < cpu_thr_multiThread:
+                    	cpuMsg += "request a lower number of threads (allowed through crab resubmit) and/or "
+            	    self.logger.info(cpuMsg+hint)
 
             summaryMsg = "\nSummary:"
             if mem_cnt:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -469,10 +469,11 @@ class status(SubCommand):
             for param, values in usage.items():
                 if values[0] < values[2]*values[1]:
                     self.logger.info("\n%sWarning%s: the max jobs %s is less than %d%% of the task requested value (%d %s), please consider to request a lower value (allowed through crab resubmit)%s." % (colors.RED, colors.NORMAL, param, values[2]*100, values[1], values[3], hint))
-            cpu_ave = (cpu_sum / run_sum)
-            cpu_thr = 0.7
-            if cpu_ave < cpu_thr:
-                self.logger.info("\n%sWarning%s: the average jobs CPU efficiency is less than %d%%, please consider to request a lower number of threads%s." % (colors.RED, colors.NORMAL, cpu_thr*100, hint))
+            if run_sum:
+                cpu_ave = (cpu_sum / run_sum)
+                cpu_thr = 0.7
+                if cpu_ave < cpu_thr:
+                    self.logger.info("\n%sWarning%s: the average jobs CPU efficiency is less than %d%%, please consider to request a lower number of threads%s." % (colors.RED, colors.NORMAL, cpu_thr*100, hint))
 
             summaryMsg = "\nSummary:"
             if mem_cnt:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -473,12 +473,12 @@ class status(SubCommand):
             if run_sum:
                 cpu_ave = (cpu_sum / run_sum)
                 cpu_thr = 0.5
-		cpu_thr_multiThread = 0.3
+                cpu_thr_multiThread = 0.3
                 if cpu_ave < cpu_thr:
                     cpuMsg = "\n%sWarning%s: the average jobs CPU efficiency is less than %d%%, please consider to " % (colors.RED, colors.NORMAL, cpu_thr*100)
-		    if numCores > 1 and cpu_ave < cpu_thr_multiThread:
-                    	cpuMsg += "request a lower number of threads (allowed through crab resubmit) and/or "
-            	    self.logger.info(cpuMsg+hint)
+                    if numCores > 1 and cpu_ave < cpu_thr_multiThread:
+                        cpuMsg += "request a lower number of threads (allowed through crab resubmit) and/or "
+                    self.logger.info(cpuMsg+hint)
 
             summaryMsg = "\nSummary:"
             if mem_cnt:


### PR DESCRIPTION
Do not print warning messages when jobs use less than the default amount of RAM or when no jobs have run yet.