### PR TITLE
Print warnings only with at least one finished job

### DIFF
--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -135,7 +135,7 @@ class status(SubCommand):
                                           shortResult['numUnpublishable'], asourl, asodb, taskname, user, crabDBInfo)
         self.printErrors(statusCacheInfo)
 
-        if not self.options.long: # already printed for this option 
+        if not self.options.long and not self.options.sort: # already printed for these options 
             self.printDetails(statusCacheInfo, self.jobids, True, maxMemory, maxJobRuntime, numCores)
 
         if self.options.summary:
@@ -404,7 +404,8 @@ class status(SubCommand):
             info = dictresult[str(jobid)]
             state = translateJobStatus(jobid)
             jobForMetrics = False
-            if state not in ['idle', 'running', 'unsubmitted']: jobForMetrics = True
+            if (state not in ['idle', 'running', 'unsubmitted']) and (not jobid.startswith('0-')): # exclude not-run and probe jobs from metric
+                jobForMetrics = True
             site = ''
             if info.get('SiteHistory'):
                 site = info['SiteHistory'][-1]
@@ -416,7 +417,7 @@ class status(SubCommand):
                     if wall > run_max: run_max = wall
             if jobForMetrics:
                 run_sum += wall
-                if not jobid.startswith('0-'): run_cnt += 1 # exclude probe jobs from metrics
+                run_cnt += 1
             wall_str = to_hms(wall)
             waste = 0
             if info.get('WallDurations'):
@@ -431,7 +432,7 @@ class status(SubCommand):
                 if jobForMetrics:
                     if mem > mem_max: mem_max = mem
                     mem_sum += mem
-                    if not jobid.startswith('0-'): mem_cnt += 1 # exclude probe jobs from metrics
+                    mem_cnt += 1
                 mem = '%d' % mem
             cpu = 'Unknown'
             if (state in ['cooloff', 'failed', 'finished']) and not wall:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -559,8 +559,8 @@ class status(SubCommand):
         elif sum(statesPJ.values()) > 0 and not self.options.long:
             if 'failed' in states:
                 states.pop('failed')
-            for status in statesSJ:
-                states[status] = states.setdefault(status, 0) + statesSJ[status]
+            for jobStatus in statesSJ:
+                states[jobStatus] = states.setdefault(jobStatus, 0) + statesSJ[jobStatus]
 
         # And if the dictionary is not empty, print it
         for jobtype, currStates in toPrint:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -486,7 +486,7 @@ class status(SubCommand):
                         cpuMsg += "request a lower number of threads (allowed through crab resubmit) and/or "
                     self.logger.info(cpuMsg+hint)
 
-            summaryMsg = "\nSummary:"
+            summaryMsg = "\nSummary of run jobs:"
             if mem_cnt:
                 summaryMsg += "\n * Memory: %dMB min, %dMB max, %.0fMB ave" % (mem_min, mem_max, mem_sum/mem_cnt)
             if run_cnt:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -568,8 +568,8 @@ class status(SubCommand):
                 total = sum(currStates[st] for st in currStates)
                 state_list = sorted(currStates)
                 self.logger.info("\n{0:32}{1} {2}".format(jobtype + ' status:', self._printState(state_list[0], 13), self._percentageString(state_list[0], currStates[state_list[0]], total)))
-                for status in state_list[1:]:
-                    self.logger.info("\t\t\t\t{0} {1}".format(self._printState(status, 13), self._percentageString(status, currStates[status], total)))
+                for jobStatus in state_list[1:]:
+                    self.logger.info("\t\t\t\t{0} {1}".format(self._printState(jobStatus, 13), self._percentageString(jobStatus, currStates[jobStatus], total)))
         return result
 
     def printErrors(self, dictresult):


### PR DESCRIPTION
Avoid getting fake warnings because based on parameters from not finished jobs (e.g. in the early stage of a task).