### PR TITLE
Fix 4755

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -462,9 +462,9 @@ def getUserDN():
     """
     Retrieve the user DN from the proxy.
     """
-    scram_cmd = 'which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`'
+    undoScram = 'which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`'
     ## Check if there is a proxy.
-    cmd = scram_cmd + "; voms-proxy-info"
+    cmd = undoScram + "; voms-proxy-info"
     process = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
     stdout, stderr = process.communicate()
     if process.returncode or not stdout:
@@ -474,7 +474,7 @@ def getUserDN():
         msg += "\n  Stderr:\n    %s" % (str(stderr).replace('\n', '\n    '))
         raise ProxyException(msg)
     ## Retrieve DN from proxy.
-    cmd = scram_cmd + "; voms-proxy-info -identity"
+    cmd = undoScram + "; voms-proxy-info -identity"
     process = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
     stdout, stderr = process.communicate()
     if process.returncode or not stdout:

--- a/src/python/CRABClient/Commands/remote_copy.py
+++ b/src/python/CRABClient/Commands/remote_copy.py
@@ -78,7 +78,7 @@ class remote_copy(SubCommand):
         command = ""
         if cmd_exist("gfal-copy") and self.options.command not in ["LCG"]:
             self.logger.info("Will use `gfal-copy` command for file transfers")
-            command = "env -i X509_USER_PROXY=%s gfal-copy -v " % os.path.abspath(self.proxyfilename)
+            command = "gfal-copy -v "
             if self.options.checksum:
                 command += "-K %s " % self.options.checksum
             command += " -T "
@@ -140,10 +140,13 @@ class remote_copy(SubCommand):
                 continue
 
             ##### Creating the command
+            # better to execut grid commands in the pre-CMS environment
+            undoScram = "which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`"
+            cmd = undoScram + cmd
+
             # timeout based on file size and download speed * 2
             maxtime = srmtimeout if not 'size' in myfile or myfile['size'] == 0 else int(ceil(2*myfile['size']/downspeed))
             localsrmtimeout = minsrmtimeout if maxtime < minsrmtimeout else maxtime # do not want a too short timeout
-
             timeout = " --srm-timeout "
             if cmd_exist("gfal-copy") and self.options.command not in ["LCG"]:
                 timeout = " -t "

--- a/src/python/CRABClient/Commands/remote_copy.py
+++ b/src/python/CRABClient/Commands/remote_copy.py
@@ -142,7 +142,6 @@ class remote_copy(SubCommand):
             ##### Creating the command
             # better to execut grid commands in the pre-CMS environment
             undoScram = "which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`"
-            cmd = undoScram + cmd
 
             # timeout based on file size and download speed * 2
             maxtime = srmtimeout if not 'size' in myfile or myfile['size'] == 0 else int(ceil(2*myfile['size']/downspeed))
@@ -150,7 +149,7 @@ class remote_copy(SubCommand):
             timeout = " --srm-timeout "
             if cmd_exist("gfal-copy") and self.options.command not in ["LCG"]:
                 timeout = " -t "
-            cmd = '%s %s %s %%s' % (command, timeout + str(localsrmtimeout) + ' ', myfile['pfn'])
+            cmd = undoScram + '; %s %s %s %%s' % (command, timeout + str(localsrmtimeout) + ' ', myfile['pfn'])
             if url_input:
                 cmd = cmd % localFilename
             else:

--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -42,9 +42,9 @@ def getUsernameFromSiteDB():
     https://cmsweb.cern.ch/sitedb/data/prod/whoami
     using the users proxy.
     """
-    scram_cmd = "which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`"
+    undoScram = "which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`"
     ## Check if there is a proxy.
-    cmd = scram_cmd + "; voms-proxy-info"
+    cmd = undoScram + "; voms-proxy-info"
     process = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
     stdout, stderr = process.communicate()
     if process.returncode or not stdout:
@@ -56,7 +56,7 @@ def getUsernameFromSiteDB():
         raise ProxyException(msg)
     ## Check if proxy is valid.
     #proxyTimeLeft = [x[x.find(':')+2:] for x in stdout.split('\n') if 'timeleft' in x][0]
-    cmd = scram_cmd + "; voms-proxy-info -timeleft"
+    cmd = undoScram + "; voms-proxy-info -timeleft"
     process = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
     stdout, stderr = process.communicate()
     if process.returncode or not stdout:
@@ -72,7 +72,7 @@ def getUsernameFromSiteDB():
         msg += "\nProxy time left = %s seconds. Please renew your proxy." % (proxyTimeLeft)
         raise ProxyException(msg)
     ## Retrieve proxy file location.
-    cmd = scram_cmd + "; voms-proxy-info -path"
+    cmd = undoScram + "; voms-proxy-info -path"
     process = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
     stdout, stderr = process.communicate()
     if process.returncode or not stdout:


### PR DESCRIPTION
do not use env -i before gfal-* but simply undo scram environment as a general protection against CMSSW vs. GRID conflicts
Also  a bit of code cleanup for readibility