### PR TITLE
No max job runtime min with automatic splitt

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -42,6 +42,7 @@ parametersMapping = {
                   'eventsperlumi'  : {'default': None,       'config': ['JobType.eventsPerLumi'],           'type': 'IntType',     'required': False},
                   'addoutputfiles' : {'default': [],         'config': ['JobType.outputFiles'],             'type': 'ListType',    'required': False},
                   'maxjobruntime'  : {'default': 1250,       'config': ['JobType.maxJobRuntimeMin'],        'type': 'IntType',     'required': False},
+                  'minAutomaticRuntimeMins' : {'default': 180, 'config': ['Data.unitsPerJob'],              'type': 'IntType',     'required': False},
                   'numcores'       : {'default': 1,          'config': ['JobType.numCores'],                'type': 'IntType',     'required': False},
                   'maxmemory'      : {'default': 2000,       'config': ['JobType.maxMemoryMB'],             'type': 'IntType',     'required': False},
                   'priority'       : {'default': 10,         'config': ['JobType.priority'],                'type': 'IntType',     'required': False},

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -217,7 +217,7 @@ class submit(SubCommand):
                 msg = "Invalid CRAB configuration: Parameter Data.unitsPerJob must be > 0, not %s." % (self.configuration.Data.unitsPerJob)
                 return False, msg
             if autoSplitt and (self.configuration.Data.unitsPerJob > autoSplittUnitsMax  or  self.configuration.Data.unitsPerJob < autoSplittUnitsMin):
-                msg = "Invalid CRAB configuration: In case of Automatic splitting, the Data.unitsPerJob parameter must be in the [%d, %d] minutes range. You askd for %d minutes." % (autoSplittUnitsMin, autoSplittUnitsMax, self.configuration.Data.unitsPerJob)
+                msg = "Invalid CRAB configuration: In case of Automatic splitting, the Data.unitsPerJob parameter must be in the [%d, %d] minutes range. You asked for %d minutes." % (autoSplittUnitsMin, autoSplittUnitsMax, self.configuration.Data.unitsPerJob)
                 return False, msg
         elif not autoSplitt:
             # The default value is only valid for automatic splitting!

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -193,6 +193,11 @@ class submit(SubCommand):
                 msg = "Invalid CRAB configuration: Parameter General.requestName should not be longer than %d characters." % (requestNameLenLimit)
                 return False, msg
 
+        ## Check that maxJobRuntimeMin is not used with Automatic splitting
+        if getattr(self.configuration.Data, 'splitting', 'Automatic') == 'Automatic' and hasattr(self.configuration.JobType, 'maxJobRuntimeMin'): 
+            msg = "The 'maxJobRuntimeMin' parameter is not compatible with the 'Automatic' splitting mode (default)."
+            return False, msg
+
         ## Check that --dryrun is not used with Automatic splitting
         if getattr(self.configuration.Data, 'splitting', 'Automatic') == 'Automatic' and self.options.dryrun: 
             msg = "The 'dryrun' option is not compatible with the 'Automatic' splitting mode (default)."

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -194,7 +194,7 @@ class submit(SubCommand):
 
         splitting = getattr(self.configuration.Data, 'splitting', 'Automatic')
         autoSplitt = True if splitting == 'Automatic' else False
-        autoSplittUnitsMin = 180 # 3 hours
+        autoSplittUnitsMin = parametersMapping['on-server']['minAutomaticRuntimeMins']['default']
         autoSplittUnitsMax = 2700 # 45 hours
         ## Check that maxJobRuntimeMin is not used with Automatic splitting
         if autoSplitt and hasattr(self.configuration.JobType, 'maxJobRuntimeMin'):


### PR DESCRIPTION
@belforte shall I fetch this value:
https://github.com/dmwm/CRABServer/blob/631c55d6cc9f5aae1c73085b1e38051d00a4494c/src/python/TaskWorker/Actions/Splitter.py#L79
instead of redefining it here:
https://github.com/dmwm/CRABClient/compare/master...lecriste:no_maxJobRuntimeMin_with_AutomaticSplitt?expand=1#diff-71ffbfee13de0d1a2aef56c45be36b39R197
?