### PR TITLE
Fixed getlog --short to validate jobids. Fix #4803

### DIFF
--- a/src/python/CRABClient/Commands/getlog.py
+++ b/src/python/CRABClient/Commands/getlog.py
@@ -24,6 +24,13 @@ class getlog(getcommand):
 
     def __call__(self):
         if self.options.short:
+            #Check if splitting is automatic
+            try:
+                splitting=self.cachedinfo['OriginalConfig'].Data.splitting
+            except AttributeError: #Default setting is 'Automatic'
+                splitting='Automatic'
+            #check the format of jobids
+            self.options.jobids = validateJobids(self.options.jobids,splitting!='Automatic')
             taskname = self.cachedinfo['RequestName']
             inputlist = {'subresource': 'webdir', 'workflow': taskname}
             serverFactory = CRABClient.Emulator.getEmulator('rest')


### PR DESCRIPTION
crab getlog --short does not function because the jobids are not validated. Fixes #4803.