### PR TITLE
Fixed caching of CMSSW Configuration

### DIFF
--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -50,10 +50,14 @@ class CMSSWConfig(object):
             configFile, pathname, description = imp.find_module(cfgBaseName, [cfgDirName])
             cacheLine = (pathname, tuple(sys.argv))
             if cacheLine in configurationCache:
-                self.fullConfig = configurationCache[cacheLine]
+                if sys.path != configurationCache[cacheLine]['path']:
+                    self.logger.warning('Warning: sys.path has changed since CMSSW configuration file was loaded.')
+                self.fullConfig = configurationCache[cacheLine]['config']
                 configFile.close()
             elif not bootstrapDone():
-                sys.path.append(os.getcwd())
+                cwd=os.getcwd()
+                if cwd not in sys.path:
+                    sys.path.append(cwd)
                 try:
                     oldstdout = sys.stdout
                     sys.stdout = open(logger.logfile, 'a')
@@ -62,7 +66,7 @@ class CMSSWConfig(object):
                     sys.stdout.close()
                     sys.stdout = oldstdout
                     configFile.close()
-                configurationCache[cacheLine] = self.fullConfig
+                configurationCache[cacheLine] = { 'config' : self.fullConfig , 'path' : sys.path }
             self.logger.info("Finished importing CMSSW configuration %s" % (userConfig))
             sys.argv = originalArgv
 

--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -48,7 +48,7 @@ class CMSSWConfig(object):
                 msg = "Additional parameters for the CMSSW configuration are: %s" % (pyCfgParams)
                 self.logger.debug(msg)
             configFile, pathname, description = imp.find_module(cfgBaseName, [cfgDirName])
-            cacheLine = (tuple(sys.path), tuple(pathname), tuple(sys.argv))
+            cacheLine = (pathname, tuple(sys.argv))
             if cacheLine in configurationCache:
                 self.fullConfig = configurationCache[cacheLine]
                 configFile.close()


### PR DESCRIPTION
`configurationCache` does not work as intended because `os.getcwd()` is appended to `sys.path` every time a configuration file is loaded. Since `sys.path` is used as part of the key, `cacheLine`, used to fetch a cached configuration, the configuration cache is never used.

Since `sys.path` is not changed anywhere else except in the (undocumented) external plugin feature there is no reason to use it as a key to the `configurationCache`, so it can just be removed from `cacheLine` and allow the `configurationCache` to be used as intended.

(Even if `sys.path` is changed reloading the file isn't the right thing to do anyway- reloading the same CMSSW configuration file multiple times can cause crashes and difficult-to-debug incorrect behavior)