### PR TITLE
Show failed (rescheduled) main jobs before tail jobs are created

### DIFF
--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -36,6 +36,7 @@ class status(SubCommand):
 
     def __init__(self, logger, cmdargs = None):
         self.jobids = None
+        self.indentation = '\t\t'
         SubCommand.__init__(self, logger, cmdargs)
 
     def __call__(self):
@@ -576,9 +577,9 @@ class status(SubCommand):
                     self.logger.info("\nThe jobs splitting of this task is 'Automatic', please refer to this FAQ for a description of the jobs status summary:\n%s", automaticSplittFAQ)
                 total = sum(currStates[st] for st in currStates)
                 state_list = sorted(currStates)
-                self.logger.info("\n{0:32}{1} \t\t {2}".format(jobtype + ' status:', self._printState(state_list[0], 13), self._percentageString(state_list[0], currStates[state_list[0]], total)))
+                self.logger.info("\n{0:32}{1}{2}{3}".format(jobtype + ' status:', self._printState(state_list[0], 13), self.indentation, self._percentageString(state_list[0], currStates[state_list[0]], total)))
                 for jobStatus in state_list[1:]:
-                    self.logger.info("\t\t\t\t{0} {1}".format(self._printState(jobStatus, 13), self._percentageString(jobStatus, currStates[jobStatus], total)))
+                    self.logger.info("\t\t\t\t{0}{1}{2}".format(self._printState(jobStatus, 13), self.indentation, self._percentageString(jobStatus, currStates[jobStatus], total)))
                 if jobtype == 'Probe jobs':
                     self.logger.info("Probe stage log:\t\t%s", proxiedWebDir+"/AutomaticSplitting_Log0.txt")
         return result
@@ -960,13 +961,13 @@ class status(SubCommand):
             states['unsubmitted'] = numFilesToPublish - numSubmittedFiles
             ## Print the publication status.
             statesList = sorted(states)
-            msg = "\nPublication status:\t\t{0} {1}".format(self._printState(statesList[0], 13), \
-                                                            self._percentageString(statesList[0], states[statesList[0]], numFilesToPublish))
+            msg = "\nPublication status:\t\t{0}{1}{2}".format(self._printState(statesList[0], 13), self.indentation, \
+                                                              self._percentageString(statesList[0], states[statesList[0]], numFilesToPublish))
             msg += pubSource
             for jobStatus in statesList[1:]:
                 if states[jobStatus]:
-                    msg += "\n\t\t\t\t{0} {1}".format(self._printState(jobStatus, 13), \
-                                                      self._percentageString(jobStatus, states[jobStatus], numFilesToPublish))
+                    msg += "\n\t\t\t\t{0}{1}{2}".format(self._printState(jobStatus, 13), self.indentation, \
+                                                        self._percentageString(jobStatus, states[jobStatus], numFilesToPublish))
             self.logger.info(msg)
             ## Print the publication errors.
             if pubInfo.get('publicationFailures'):

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -591,8 +591,6 @@ class status(SubCommand):
                     self.logger.info("\t\t\t\t{0}{1}{2}".format(self._printState(jobStatus, 13), self.indentation, self._percentageString(jobStatus, currStates[jobStatus], total)))
                 if jobtype == 'Probe jobs':
                     self.logger.info("Probe stage log:\t\t%s", proxiedWebDir+"/AutomaticSplitting_Log0.txt")
-=======
->>>>>>> central/master
         return result
 
     def printErrors(self, dictresult, automaticSplitt):

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -51,7 +51,7 @@ class status(SubCommand):
         combinedStatus = getColumn(crabDBInfo, 'tm_task_status')
 
         user = getColumn(crabDBInfo, 'tm_username')
-        self.webdir = getColumn(crabDBInfo, 'tm_user_webdir')
+        webdir = getColumn(crabDBInfo, 'tm_user_webdir')
         rootDagId = getColumn(crabDBInfo, 'clusterid') #that's the condor id from the TW
         asourl = getColumn(crabDBInfo, 'tm_asourl')
         asodb = getColumn(crabDBInfo, 'tm_asodb')
@@ -70,7 +70,7 @@ class status(SubCommand):
 
         self.logger.debug("The CRAB server submitted your task to the Grid scheduler (cluster ID: %s)" % rootDagId)
 
-        if not self.webdir:
+        if not webdir:
             # Query condor through the server for information about this task
             uri = self.getUrl(self.instance, resource = 'workflow')
             params = {'subresource': 'taskads', 'workflow': taskname}
@@ -95,7 +95,7 @@ class status(SubCommand):
                 combinedStatus = "UNKNOWN"
             return self.makeStatusReturnDict(crabDBInfo, combinedStatus, statusFailureMsg=failureMsg)
 
-        self.logger.debug("Webdir is located at %s", self.webdir)
+        self.logger.debug("Webdir is located at %s", webdir)
 
         proxiedWebDir = getProxiedWebDir(taskname, self.serverurl, uri, self.proxyfilename, self.logger.debug)
         if not proxiedWebDir:
@@ -103,7 +103,7 @@ class status(SubCommand):
             msg += "\nWill fall back to the regular webdir url for file downloads "
             msg += "but will likely fail if the client is located outside CERN."
             self.logger.debug(msg)
-            proxiedWebDir = self.webdir
+            proxiedWebDir = webdir
         self.logger.debug("Proxied webdir is located at %s", proxiedWebDir)
 
         # Download status_cache file

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -589,8 +589,6 @@ class status(SubCommand):
                 self.logger.info("\n{0:32}{1}{2}{3}".format(jobtype + ' status:', self._printState(state_list[0], 13), self.indentation, self._percentageString(state_list[0], currStates[state_list[0]], total)))
                 for jobStatus in state_list[1:]:
                     self.logger.info("\t\t\t\t{0}{1}{2}".format(self._printState(jobStatus, 13), self.indentation, self._percentageString(jobStatus, currStates[jobStatus], total)))
-                if jobtype == 'Probe jobs':
-                    self.logger.info("Probe stage log:\t\t%s", proxiedWebDir+"/AutomaticSplitting_Log0.txt")
         return result
 
     def printErrors(self, dictresult, automaticSplitt):

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -557,7 +557,7 @@ class status(SubCommand):
             if sum(statesPJ.values()) > 0:
                 terminate(statesPJ, 'failed')
                 terminate(statesPJ, 'finished')
-                terminate(states, 'failed', target='rescheduled')
+                terminate(states, 'failed', target='rescheduled as tail jobs')
         elif sum(statesPJ.values()) > 0 and not self.options.long:
             if 'failed' in states:
                 states.pop('failed')
@@ -572,7 +572,7 @@ class status(SubCommand):
                     self.logger.info("\nThe jobs splitting of this task is 'Automatic', please refer to this FAQ for a description of the jobs status summary:\n%s", automaticSplittFAQ)
                 total = sum(currStates[st] for st in currStates)
                 state_list = sorted(currStates)
-                self.logger.info("\n{0:32}{1} {2}".format(jobtype + ' status:', self._printState(state_list[0], 13), self._percentageString(state_list[0], currStates[state_list[0]], total)))
+                self.logger.info("\n{0:32}{1} \t\t {2}".format(jobtype + ' status:', self._printState(state_list[0], 13), self._percentageString(state_list[0], currStates[state_list[0]], total)))
                 for jobStatus in state_list[1:]:
                     self.logger.info("\t\t\t\t{0} {1}".format(self._printState(jobStatus, 13), self._percentageString(jobStatus, currStates[jobStatus], total)))
         return result

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -533,18 +533,18 @@ class status(SubCommand):
         result['jobsPerStatus'] = jobsPerStatus
         result['jobList'] = jobList
 
-        # Collect information about probejobs and subjobs
-        # Create a dictionary like { 'finished' : 1, 'running' : 3}
+        # Collect information about probe and tail jobs
+        # Create dictionaries like {'finished' : 1, 'running' : 3}
         states = {}
         statesPJ = {}
-        statesSJ = {}
+        statesTJ = {}
         failedProcessing = 0
         for jobid, statusDict in statusCacheInfo.iteritems():
             jobStatus = statusDict['State']
             if jobid.startswith('0-'):
                 statesPJ[jobStatus] = statesPJ.setdefault(jobStatus, 0) + 1
             elif '-' in jobid:
-                statesSJ[jobStatus] = statesSJ.setdefault(jobStatus, 0) + 1
+                statesTJ[jobStatus] = statesTJ.setdefault(jobStatus, 0) + 1
             else:
                 states[jobStatus] = states.setdefault(jobStatus, 0) + 1
                 if jobStatus == 'failed':
@@ -560,7 +560,7 @@ class status(SubCommand):
 
         toPrint = [('Jobs', states)]
         if self.options.long:
-            toPrint = [('Probe jobs', statesPJ), ('Jobs', states), ('Tail jobs', statesSJ)]
+            toPrint = [('Probe jobs', statesPJ), ('Jobs', states), ('Tail jobs', statesTJ)]
             if automaticSplitt:
                 toPrint[1] = ('Main jobs', states)
             if sum(statesPJ.values()) > 0:
@@ -568,10 +568,12 @@ class status(SubCommand):
                 terminate(statesPJ, 'finished')
                 terminate(states, 'failed', target='rescheduled as tail jobs')
         elif sum(statesPJ.values()) > 0:
-            if 'failed' in states:
-                states.pop('failed')
-            for jobStatus in statesSJ:
-                states[jobStatus] = states.setdefault(jobStatus, 0) + statesSJ[jobStatus]
+            if statesTJ:
+                states.pop('failed', None) # remove failed from main jobs as they have been rescheduled as tail jobs
+                for jobStatus in statesTJ:
+                    states[jobStatus] = states.setdefault(jobStatus, 0) + statesTJ[jobStatus]
+            else:
+                terminate(states, 'failed', target='rescheduled as tail jobs')
 
         # And if the dictionary is not empty, print it
         if automaticSplitt:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -35,6 +35,9 @@ class status(SubCommand):
     shortnames = ['st']
 
     def __init__(self, logger, cmdargs = None):
+        self.taskname = None
+        self.webdir = None
+        self.schedd = None
         self.jobids = None
         SubCommand.__init__(self, logger, cmdargs)
 

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -556,11 +556,13 @@ class status(SubCommand):
         toPrint = [('Jobs', states)]
         if self.options.long:
             toPrint = [('Probe jobs', statesPJ), ('Jobs', states), ('Tail jobs', statesSJ)]
+            if automaticSplitt:
+                toPrint[1] = ('Main jobs', states)
             if sum(statesPJ.values()) > 0:
                 terminate(statesPJ, 'failed')
                 terminate(statesPJ, 'finished')
                 terminate(states, 'failed', target='rescheduled as tail jobs')
-        elif sum(statesPJ.values()) > 0 and not self.options.long:
+        elif sum(statesPJ.values()) > 0:
             if 'failed' in states:
                 states.pop('failed')
             for jobStatus in statesSJ:


### PR DESCRIPTION
Before tail jobs are created, do not remove failed jobs from main jobs and print them as rescheduled.