### PR TITLE
Add additional cmssw pythonpath if CRAB_CMSSW_SITE_PACKAGES is set

### DIFF
--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -48,6 +48,13 @@ class CMSSWConfig(object):
                 sys.argv.extend(pyCfgParams)
                 msg = "Additional parameters for the CMSSW configuration are: %s" % (pyCfgParams)
                 self.logger.debug(msg)
+
+            #Add cmssw python paths
+            if 'CRAB_CMSSW_SITE_PACKAGES' in os.environ:
+                import site
+                for p in os.environ['CRAB_CMSSW_SITE_PACKAGES'].split(os.pathsep):
+                    site.addsitedir(p)
+
             # details of user configuration file:
             configFile, pathname, description = imp.find_module(cfgBaseName, [cfgDirName])
             cacheLine = (pathname, tuple(sys.argv))


### PR DESCRIPTION
The new crab startup script https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_11_1_X/master/_crab-startup.file runs in clean env but it still needs to access CMSSW's `PYTHONPATH` for `crab submit` command. I propose that crab use `CRAB_CMSSW_SITE_PACKAGES` env variable to include extra cmssw python paths when it deals with CMSSW configuration. This change should not break crab's existing setup as no one should be setting `CRAB_CMSSW_SITE_PACKAGES` env variable. 
I was abe to submit a test job with this change plus https://github.com/cms-sw/cmsdist/pull/5442/files for new crab startup script