### PR TITLE
Fixed validation of PSets in CMSSWConfig.py

### DIFF
--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -252,11 +252,11 @@ class CMSSWConfig(object):
             msg = "Validation of CMSSW configuration was requested, but there is no configuration to validate."
             return False, msg
 
-        if not getattr(self.fullConfig, 'process'):
+        if not getattr(self.fullConfig, 'process', None):
             msg = "Invalid CMSSW configuration: 'process' object is missing or is wrongly defined."
             return False, msg
 
-        if not getattr(self.fullConfig.process, 'source'):
+        if not getattr(self.fullConfig.process, 'source', None):
             msg = "Invalid CMSSW configuration: 'process' object is missing attribute 'source' or the attribute is wrongly defined."
             return False, msg
 


### PR DESCRIPTION
The current validation of PSets in CMSSWConfig.py uses ```if not getattr(...)``` in a few places to check if an attribute is defined. But ```getattr``` throws an AttributeError if the attribute is not defined, and so the helpful error message is not shown.

Adding a default of ```none``` keeps this from throwing when ```process``` and ```source``` are undefined, and does not change the behavior in other cases (e.g. when process or source are defined as ```None```).