### PR TITLE
Fix PSet raising a SystemExit causing an UnboundLocalError

### DIFF
--- a/src/python/CRABAPI/RawCommand.py
+++ b/src/python/CRABAPI/RawCommand.py
@@ -4,6 +4,8 @@
 """
 import CRABAPI
 
+import traceback
+
 from CRABClient.ClientUtilities import initLoggers, flushMemoryLogger, removeLoggerHandlers
 
 
@@ -49,6 +51,12 @@ def execRaw(command, args):
         # CRABClient #4283 should make this less ugly
         if se.code == 2:
             raise CRABAPI.BadArgumentException
+        else:
+        # We can reach here if the PSet raises a SystemExit exception
+        # Without this, CRAB raises a confusing UnboundLocalError
+            logger.error('PSet raised a SystemExit. Traceback follows:')
+            logger.error(traceback.format_exc())
+            raise
     finally:
         flushMemoryLogger(tblogger, memhandler, logger.logfile)
         removeLoggerHandlers(tblogger)


### PR DESCRIPTION
Currently, if the PSet raises a SystemExit when a job is being submitted via the CRAB API, the API raises a confusing UnboundLocalError.

The new code instead prints a traceback and then reraises the exception.

As an aside, this can still cause some confusion if the end user happens to call ```sys.exit(2)```.

Example submit script:
```
from CRABClient.UserUtilities import config
from CRABAPI.RawCommand import crabCommand

config=config()
config.Site.storageSite='T3_US_FNALLPC'
config.JobType.pluginName='PrivateMC'
config.JobType.psetName='PSet.py'
config.Data.splitting='EventBased'
config.Data.unitsPerJob=1
config.Data.totalUnits=1
config.Data.outputPrimaryDataset='None'
config.Data.publication=False
crabCommand('submit',config=config)
```
with PSet.py:
```
import sys
sys.exit(1)
```

currently gives:
```
Importing CMSSW configuration PSet.py
Traceback (most recent call last):
  File "test.py", line 13, in <module>
    crabCommand('submit',config=config)
  File "/cvmfs/cms.cern.ch/crab3/slc6_amd64_gcc493/cms/crabclient/3.3.2001/lib/python2.7/site-packages/CRABAPI/RawCommand.py", line 26, in crabCommand
    return execRaw(command, arguments)
  File "/cvmfs/cms.cern.ch/crab3/slc6_amd64_gcc493/cms/crabclient/3.3.2001/lib/python2.7/site-packages/CRABAPI/RawCommand.py", line 56, in execRaw
    return res
UnboundLocalError: local variable 'res' referenced before assignment
```