### PR TITLE
Create tmp crab3checkwrite file only if lfn2pfn was successful (fix #4961)

### DIFF
--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -76,13 +76,13 @@ class checkwrite(SubCommand):
         timestamp = str(time.strftime("%Y%m%d_%H%M%S"))
         self.filename = 'crab3checkwrite_' + timestamp  + '.tmp'
         self.subdir = 'crab3checkwrite_' + timestamp
-        self.createFile()
         lfn = self.lfnPrefix + '/' + self.subdir + '/' + self.filename
         site = self.options.sitename
         try:
             pfn = self.getPFN(site=site, lfn=lfn, username=username)
         except Exception:
             return {'status': 'FAILED'}
+        self.createFile()
         self.logger.info("Will use PFN: %s", pfn)
         dirpfn = pfn[:len(pfn)-len(self.filename)]
         self.logger.info('\nAttempting to create (dummy) directory %s and copy (dummy) file %s to %s\n' % (self.subdir, self.filename, self.lfnPrefix))


### PR DESCRIPTION
Create tmp crab3checkwrite file only if lfn2pfn was successful (fix #4961)

Tested using https://twiki.cern.ch/twiki/bin/view/CMSPublic/CMSCrabClient#Develop_for_CRABClient instructions.