### PR TITLE
upload logfile to s3 (fix #4971)

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -222,10 +222,6 @@ def uploadlogfile(logger, proxyfilename, taskname=None, logfilename=None, logpat
         doupload = False
         
     if doupload:
-        if not username:
-            from CRABClient.UserUtilities import getUsername
-            username = getUsername(proxyFile=proxyfilename, logger=logger)
-
         # uploadLog is executed directly from crab main script, does not inherit from SubCommand
         # so it needs its own REST server instantiation
         restClass = CRABClient.Emulator.getEmulator('rest')
@@ -241,13 +237,16 @@ def uploadlogfile(logger, proxyfilename, taskname=None, logfilename=None, logpat
         if 'S3' in cacheurl.upper():
             objecttype = 'clientlog'
             uploadToS3(crabserver=crabserver, filepath=logpath, objecttype=objecttype, taskname=taskname, logger=logger)
-            logfileurl = getDownloadUrlFromS3(crabserver=crabserver, filepath=logpath, objecttype=objecttype, taskname=taskname, username=username, logger=logger)
+            logfileurl = getDownloadUrlFromS3(crabserver=crabserver, objecttype=objecttype, taskname=taskname, logger=logger)
         else:
             cacheurldict = {'endpoint': cacheurl, "pycurl": True}
             ufc = UserFileCache(cacheurldict)
             logger.debug("cacheURL: %s\nLog file name: %s" % (cacheurl, logfilename))
             ufc.uploadLog(logpath, logfilename)
             logfileurl = cacheurl + '/logfile?name='+str(logfilename)
+            if not username:
+              from CRABClient.UserUtilities import getUsername
+              username = getUsername(proxyFile=proxyfilename, logger=logger)            
             logfileurl += '&username='+str(username)
         logger.info("Log file URL: %s" % (logfileurl))
         logger.info("%sSuccess%s: Log file uploaded successfully." % (colors.GREEN, colors.NORMAL))

--- a/src/python/CRABClient/Commands/uploadlog.py
+++ b/src/python/CRABClient/Commands/uploadlog.py
@@ -25,6 +25,7 @@ class uploadlog(SubCommand):
 
     def __call__(self):
         self.logger.debug("uploadlog started")
+        taskname = None
         #veryfing the log file exist
         if self.options.logpath is not None:
             logfilename = str(time.strftime("%Y-%m-%d_%H%M%S"))+'_crab.log'
@@ -32,7 +33,8 @@ class uploadlog(SubCommand):
         elif os.path.isfile(self.logfile):
             self.logger.debug("crab.log exists")
             try:
-                logfilename = str(self.cachedinfo['RequestName'])+".log"
+                taskname = self.cachedinfo['RequestName']
+                logfilename = str(taskname)+".log"
             except:
                 self.logger.info("Couldn't get information from .requestcache (file likely not created due to submission failure), try\n"
                         "'crab uploadlog --logpath=<path-to-log-file-in-project-dir>'")
@@ -43,7 +45,7 @@ class uploadlog(SubCommand):
             raise ConfigurationException
 
         self.logger.info("Will upload file %s." % (self.logfile))
-        logfileurl = uploadlogfile(self.logger, self.proxyfilename, logfilename = logfilename, \
+        logfileurl = uploadlogfile(self.logger, self.proxyfilename, taskname = taskname, logfilename = logfilename, \
                                    logpath = str(self.logfile), instance = self.instance, \
                                    serverurl = self.serverurl)
         return {'result' : {'status' : 'SUCCESS' , 'logurl' : logfileurl}}
@@ -84,3 +86,4 @@ class uploadlog(SubCommand):
                 ex = MissingOptionException(msg)
                 ex.missingOption = "task"
             raise ex
+


### PR DESCRIPTION
@belforte following changes will upload log file to s3 if `cacheSSL` for a given task in https://gitlab.cern.ch/crab3/CRAB3ServerConfig/-/blob/master/cmsweb-rest-config.json points to s3. otherwise logfile will be uploaded to old crabcache.

`uploadLog` to s3  only works with `crab uploadlog --dir` option. 
if `crab uploadlog --logpath` is used, log file is uploaded to old `crabcache` as in that case `cacheSSL` points to `https://cmsweb.cern.ch:8443/crabcache`. as already discussed, we should agree if `--logpath` option should be kept going forward 