### PR TITLE
make crab commands use python3

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This contains the hooks to call the different command plug-ins.
 It is not intended to contain any of the CRAB-3 client logic,


### PR DESCRIPTION
this makes crab(-dev) use python3 and work with CMSSW_12_0_0_pre6
(tested)

we can worry later about a way to pick python2/3 automatically depending on release along the lines which Shahzad suggested. As long as we keep crab-prod for CMSSW <=11 and crab-dev for CMSSW_12 only, this will suffice.