### PR TITLE
unlink file with error info (fix #5079)

### DIFF
--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -120,11 +120,21 @@ def curlGetFileFromURL(url, filename = None, proxyfilename = None, logger=None):
     if logger:
         logger.debug("Will execute:\n%s", downloadCommand)
     stdout, stderr, rc = execute_command(downloadCommand, logger=logger)
+    errorDetails = ''
+
+    if rc != 0:
+        os.unlink(filename)
+        httpCode = 503
+    else:
+        httpCode = int(stdout)
+        if httpCode != 200:
+            with open(filename) as f:
+                errorDetails = f.read()
+            os.unlink(filename)
     if logger:
-        logger.debug('exitcode: %s\nstdout: %s\nstderr: %s', rc, stdout, stderr)
-    httpCode = int(stdout)
-    retValue = rc if rc != 0 else httpCode
-    return retValue
+        logger.debug('exitcode: %s\nstdout: %s\nstderr: %s\nerror details: %s', rc, stdout, stderr, errorDetails)
+	
+    return httpCode
 
 
 def getLumiListInValidFiles(dataset, dbsurl = 'phys03'):


### PR DESCRIPTION
Once `curl` tries to get file which does not exists (http 404 error), details will still be written to `filename`. However, details are logged and file is removed.

alternative was to add `-f` flag to `curl` command and in this case file with error details would not be created at all, but as per `curl` documentation:

> In normal cases when an HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This flag will prevent curl from outputting that and return error 22

this flag will prevent `curl` from outputting error, so we loose this information (while we want to keep it)

alternative to `-f` flag would be to use `--fail-with-body`, which:

> This flag will still allow curl to output and save that content but also to return error 22.  This is an alternative option to -f, --fail which makes curl fail for the same circumstances but without saving the content. 

however, this option is available in `curl` 7.76.0 version, while we are using older one.

changes tested on lxplus.

 