### PR TITLE
move WMCore Config to CRABClient repo (fix #4974)

### DIFF
--- a/bin/crab2cfgTOcrab3py
+++ b/bin/crab2cfgTOcrab3py
@@ -15,7 +15,7 @@ import os
 from ConfigParser import RawConfigParser
 from optparse import OptionParser
 
-from WMCore.Configuration import Configuration, saveConfigurationFile
+from CRABClient.Configuration import Configuration, saveConfigurationFile
 
 DEFAULT_UNITS_PER_JOB = 50
 

--- a/bin/crab3bootstrap
+++ b/bin/crab3bootstrap
@@ -28,7 +28,7 @@ from CRABClient.ClientExceptions import ClientException, ConfigurationException
 from CRABClient.ClientUtilities import BOOTSTRAP_ENVFILE, BOOTSTRAP_INFOFILE, BOOTSTRAP_CFGFILE, LOGLEVEL_MUTE
 from CRABClient.ClientUtilities import setSubmitParserOptions, validateSubmitOptions, initLoggers, setConsoleLogLevelVar, flushMemoryLogger
 
-from WMCore.Configuration import loadConfigurationFile
+from CRABClient.Configuration import loadConfigurationFile
 
 
 def saveScramEnv(destFile, logger):

--- a/doc/ExampleConfiguration.py
+++ b/doc/ExampleConfiguration.py
@@ -2,7 +2,7 @@
 This is an example of a minimal CRAB3 configuration file.
 """
 
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 import os
 
 config = Configuration()

--- a/doc/FullConfiguration.py
+++ b/doc/FullConfiguration.py
@@ -3,7 +3,7 @@ This is an example configuration file for CRAB3 client, covering
 most of the available configuration options.
 """
 
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 import os
 
 config = Configuration()

--- a/doc/config/ExampleConfiguration.py
+++ b/doc/config/ExampleConfiguration.py
@@ -2,7 +2,7 @@
 This is a test example of configuration file for CRAB-3 client
 """
 
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 import os
 
 config = Configuration()

--- a/doc/config/FullConfiguration.py
+++ b/doc/config/FullConfiguration.py
@@ -2,7 +2,7 @@
 This is a test example of configuration file for CRAB-3 client
 """
 
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 import os
 
 config = Configuration()

--- a/doc/crabclient/userdoc/configuration.rst
+++ b/doc/crabclient/userdoc/configuration.rst
@@ -128,7 +128,7 @@ If another required CRAB3 parameter is not specified in the CRAB2 config file yo
 
 And opening the config file you will see which parameters you need to modify::
 
-    from WMCore.Configuration import Configuration
+    from CRABClient.Configuration import Configuration
     config = Configuration()
     config.section_('General')
     config.General.requestName = 'crab3taskname'

--- a/src/python/CRABAPI/Abstractions.py
+++ b/src/python/CRABAPI/Abstractions.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import CRABAPI.TopLevel
 import CRABClient.Commands.submit
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 class Task(object):
     """
         Task - Wraps methods and attributes for a single analysis task

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -6,7 +6,7 @@ import types
 from ast import literal_eval
 from datetime import timedelta
 
-from WMCore.Configuration import loadConfigurationFile, Configuration
+from CRABClient.Configuration import loadConfigurationFile, Configuration
 
 from ServerUtilities import SERVICE_INSTANCES
 

--- a/src/python/CRABClient/Configuration.py
+++ b/src/python/CRABClient/Configuration.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python
+# pylint: disable=C0321,C0103,W0622
+# W0622: redefined-builtin
+"""
+_Configuration_
+
+Module dealing with Configuration file in python format
+
+
+"""
+
+import imp
+import os
+import sys
+import traceback
+
+PY3 = sys.version_info[0] == 3
+
+# PY3 compatibility (can be removed once python2 gets dropped)
+if PY3:
+    basestring = str
+    unicode = str
+    long = int
+
+_SimpleTypes = [
+    bool,
+    float,
+    basestring,  # For py2/py3 compatibility, don't let futurize remove PY3 Remove when python 3 transition complete
+    str,
+    long,  # PY3: Not needed in python3, will be converted to duplicate int
+    type(None),
+    int,
+]
+
+_ComplexTypes = [
+    dict,
+    list,
+    tuple,
+]
+
+_SupportedTypes = []
+_SupportedTypes.extend(_SimpleTypes)
+_SupportedTypes.extend(_ComplexTypes)
+
+
+def formatAsString(value):
+    """
+    _format_
+
+    format a value as python
+    keep parameters simple, trust python...
+    """
+    if isinstance(value, str):
+        value = "\'%s\'" % value
+    return str(value)
+
+
+def formatNative(value):
+    """
+    _formatNative_
+
+    Like the format function, but allowing passing of ints, floats, etc.
+    """
+
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        return dict
+    return formatAsString(value)
+
+
+class ConfigSection(object):
+    # pylint: disable=protected-access
+    """
+    _ConfigSection_
+
+    Chunk of configuration information
+    """
+
+    def __init__(self, name=None):
+        object.__init__(self)
+        self._internal_documentation = ""
+        self._internal_name = name
+        self._internal_settings = set()
+        self._internal_docstrings = {}
+        self._internal_children = set()
+        self._internal_parent_ref = None
+        # The flag skipChecks controls weather each parameter added to the configuration
+        # should be a primitive or complex type that can be "jsonized"
+        # By default it is false, but ConfigurationEx instances set it to True
+        self._internal_skipChecks = False
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return (
+                (self._internal_documentation == other._internal_documentation) and
+                (self._internal_name == other._internal_name) and
+                (self._internal_settings == other._internal_settings) and
+                (self._internal_docstrings == other._internal_docstrings) and
+                (self._internal_children == other._internal_children) and
+                (self._internal_parent_ref == other._internal_parent_ref))
+        return id(self) == id(other)
+
+    def _complexTypeCheck(self, name, value):
+
+        if isinstance(value, tuple(_SimpleTypes)):
+            return
+        elif isinstance(value, tuple(_ComplexTypes)):
+            vallist = value
+            if isinstance(value, dict):
+                vallist = value.values()
+            for val in vallist:
+                self._complexTypeCheck(name, val)
+        else:
+            msg = "Not supported type in sequence:"
+            msg += "%s\n" % type(value)
+            msg += "for name: %s and value: %s\n" % (name, value)
+            msg += "Added to WMAgent Configuration."
+            msg += "Use ConfigurationEx to skip checks on config params"
+            raise RuntimeError(msg)
+
+    def __setattr__(self, name, value):
+        if name.startswith("_internal_"):
+            # skip test for internal setting
+            object.__setattr__(self, name, value)
+            return
+
+        if isinstance(value, ConfigSection):
+            # child ConfigSection
+            self._internal_children.add(name)
+            self._internal_settings.add(name)
+            value._internal_parent_ref = self
+            object.__setattr__(self, name, value)
+            return
+
+        if isinstance(value, unicode):
+            value = str(value)
+
+        # for backward compatibility use getattr and sure to work if the
+        # _internal_skipChecks flag is not set
+        if not getattr(self, '_internal_skipChecks', False):
+            self._complexTypeCheck(name, value)
+
+        object.__setattr__(self, name, value)
+        self._internal_settings.add(name)
+        return
+
+    def __delattr__(self, name):
+        if name.startswith("_internal_"):
+            # skip test for internal setting
+            object.__delattr__(self, name)
+            return
+        else:
+            if name in self._internal_children:
+                self._internal_children.remove(name)
+            if name in self._internal_settings:
+                self._internal_settings.remove(name)
+            object.__delattr__(self, name)
+            return
+
+    def __iter__(self):
+        for attr in self._internal_settings:
+            yield getattr(self, attr)
+
+    def __add__(self, otherSection):
+        """
+        _addition operator_
+
+        Define addition for two config section objects
+
+        """
+        for setting in otherSection._internal_settings:
+            settingInstance = getattr(otherSection, setting)
+            if setting in self._internal_settings:
+                currentSetting = getattr(self, setting)
+                if not isinstance(currentSetting, type(settingInstance)) \
+                        and currentSetting is not None and settingInstance is not None:
+                    msg = "Trying to overwrite a setting with mismatched types"
+                    msg += "%s.%s is not the same type as %s.%s" % (
+                        self._internal_name, setting,
+                        otherSection._internal_name, setting
+                    )
+
+                    raise TypeError(msg)
+            self.__setattr__(setting, settingInstance)
+        return self
+
+    def section_(self, sectionName):
+        """
+        _section_
+
+        Get a section by name, create it if not present,
+        returns a ConfigSection instance
+
+        """
+        if sectionName in self.__dict__:
+            return self.__dict__[sectionName]
+        newSection = ConfigSection(sectionName)
+        self.__setattr__(sectionName, newSection)
+        return object.__getattribute__(self, sectionName)
+
+    def pythonise_(self, **options):
+        """
+        convert self into list of python format strings
+
+        options available
+
+        document - if True will add document_ calls to the python
+        comment  - if True will add docs as comments.
+
+        """
+        document = options.get('document', False)
+        comment = options.get('comment', False)
+        prefix = options.get('prefix', None)
+
+        if prefix is not None:
+            myName = "%s.%s" % (prefix, self._internal_name)
+        else:
+            myName = self._internal_name
+
+        result = []
+        if document:
+            result.append("%s.document_(\"\"\"%s\"\"\")" % (
+                myName,
+                self._internal_documentation)
+                          )
+        if comment:
+            result.append("# %s: %s" % (
+                myName, self._internal_documentation.replace(
+                        "\n", "\n# "),
+            ))
+        for attr in self._internal_settings:
+            if attr in self._internal_children:
+                result.append("%s.section_(\'%s\')" % (myName, attr))
+                result.extend(getattr(self, attr).pythonise_(
+                        document=document, comment=comment, prefix=myName))
+                continue
+            if attr in self._internal_docstrings:
+                if comment:
+                    result.append("# %s.%s: %s" % (
+                        myName, attr,
+                        self._internal_docstrings[attr].replace("\n", "\n# ")
+                    ))
+            result.append("%s.%s = %s" % (
+                myName,
+                attr, formatAsString(getattr(self, attr))
+            ))
+
+            if attr in self._internal_docstrings:
+                if document:
+                    result.append(
+                            "%s.document_(\"\"\"%s\"\"\", \'%s\')" % (
+                                myName,
+                                self._internal_docstrings[attr], attr))
+        return result
+
+    def dictionary_(self):
+        """
+        _dictionary_
+
+        Create a dictionary representation of this object.
+
+        This method does not take into account possible ConfigSections
+        as attributes of self (i.e. sub-ConfigSections) as the
+        dictionary_whole_tree_() method does.
+        The reason for this method to stay is that WebTools.Root.py
+        depends on a few places to check itself like:
+        if isinstance(param_value, ConfigSection) ...
+
+        """
+        result = {}
+        for x in self._internal_settings:
+            result.__setitem__(x, getattr(self, x))
+        return result
+
+    def dictionary_whole_tree_(self):
+        """
+        Create a dictionary representation of this object.
+
+        ConfigSection.dictionary_() method needs to expand possible
+        items that are ConfigSection instances (those which appear
+        in the _internal_children set).
+        Also these sub-ConfigSections have to be made dictionaries
+        rather than putting e.g.
+        'Task1': <WMCore.Configuration.ConfigSection object at 0x104ccb50>
+
+        """
+        result = {}
+        for x in self._internal_settings:
+            if x in self._internal_children:
+                v = getattr(self, x)
+                result[x] = v.dictionary_whole_tree_()
+                continue
+            result.__setitem__(x, getattr(self, x))  # the same as result[x] = value
+        return result
+
+    def document_(self, docstring, parameter=None):
+        """
+        _document_
+
+        Add docs/comments to parameters. If the parameter is None, then
+        the documentation is provided to the section itself.
+        This method will overwrite any existing documentation
+
+        """
+        if parameter is None:
+            self._internal_documentation = str(docstring)
+            return
+        self._internal_docstrings[parameter] = str(docstring)
+        return
+
+    def __str__(self):
+        """
+        string representation, dump to python format
+        """
+        result = ""
+        for pystring in self.pythonise_():
+            result += "%s\n" % pystring
+        return result
+
+    def documentedString_(self):
+        """
+        string representation, dump to python format
+        include docs as calls to document_
+        """
+        result = ""
+        for pystring in self.pythonise_(document=True):
+            result += "%s\n" % pystring
+        return result
+
+    def commentedString_(self):
+        """
+        string representation, dump to python format
+        include docs as comments
+        """
+        result = ""
+        for pystring in self.pythonise_(comment=True):
+            result += "%s\n" % pystring
+        return result
+
+    # Added by mnorman to make our strategy to use configSections viable
+    def listSections_(self):
+        """
+        _listSections_
+
+        Retrieve a list of components from the components
+        configuration section
+
+        """
+        comps = self._internal_settings
+        return list(comps)
+
+
+class Configuration(object):
+    # pylint: disable=protected-access
+    """
+    _Configuration_
+
+    Top level configuration object
+
+    """
+
+    def __init__(self):
+        object.__init__(self)
+        self._internal_components = []
+        self._internal_webapps = []
+        self._internal_sections = []
+        Configuration._instance = self
+
+    def __add__(self, otherConfig):
+        """
+        _addition operator_
+
+        Define addition for two config section objects
+
+        """
+        for configSect in otherConfig._internal_sections:
+            if configSect not in self._internal_sections:
+                self.section_(configSect)
+            getattr(self, configSect) + getattr(otherConfig, configSect)
+        return self
+
+    def __setattr__(self, name, value):
+        if name.startswith("_internal_"):
+            # skip test for internal settings
+            object.__setattr__(self, name, value)
+            return
+        if not isinstance(value, ConfigSection):
+            msg = "Can only add objects of type ConfigSection to Configuration"
+            raise RuntimeError(msg)
+
+        object.__setattr__(self, name, value)
+        return
+
+    def __delattr__(self, name):
+        if name.startswith("_internal_"):
+            # skip test for internal setting
+            object.__delattr__(self, name)
+            return
+        else:
+            if name in self._internal_sections:
+                self._internal_sections.remove(name)
+            if name in self._internal_components:
+                self._internal_components.remove(name)
+            if name in self._internal_webapps:
+                self._internal_webapps.remove(name)
+            object.__delattr__(self, name)
+            return
+
+    @staticmethod
+    def getInstance():
+        return getattr(Configuration, "_instance", None)
+
+    def listComponents_(self):
+        """
+        _listComponents_
+
+        Retrieve a list of components from the components
+        configuration section
+
+        """
+        comps = self._internal_components
+        return comps
+
+    def listWebapps_(self):
+        """
+        _listWebapps_
+
+        Retrieve a list of webapps from the webapps configuration section.
+        """
+        return self._internal_webapps
+
+    def listSections_(self):
+        """
+        _listSections_
+
+        Retrieve a list of components from the components
+        configuration section
+
+        """
+        comps = self._internal_sections
+        return comps
+
+    def section_(self, sectionName):
+        """
+        _section_
+
+        Get a section by name, create it if not present,
+        returns a ConfigSection instance
+
+        """
+        if sectionName in self.__dict__:
+            return self.__dict__[sectionName]
+        newSection = ConfigSection(sectionName)
+        self.__setattr__(sectionName, newSection)
+        self._internal_sections.append(sectionName)
+        return object.__getattribute__(self, sectionName)
+
+    def component_(self, componentName):
+        """
+        _component_
+
+        Get the config for the named component, add it
+        if not present, returns a ConfigSection with
+        default fields for the component added to it
+
+        """
+        compSection = self.section_(componentName)
+        if componentName not in self._internal_components:
+            self._internal_components.append(componentName)
+            compSection.componentDir = None
+
+        return compSection
+
+    def webapp_(self, webappName):
+        """
+        _webapp_
+
+        Get the config for the named webapp, add it if not present.  This will
+        return a ConfigSection with default fields for the webapp added to it.
+        """
+        webappSection = self.section_(webappName)
+        if webappName not in self._internal_webapps:
+            self._internal_webapps.append(webappName)
+            webappSection.section_("Webtools")
+            webappSection.section_("database")
+            webappSection.section_("security")
+
+        return webappSection
+
+    def pythonise_(self, **options):
+        """
+        write as python format
+
+
+        document - if True will add document_ calls to the python
+        comment  - if True will add docs as comments.
+
+        """
+        document = options.get('document', False)
+        comment = options.get('comment', False)
+
+        result = "from WMCore.Configuration import Configuration\n"
+        result += "config = Configuration()\n"
+        for sectionName in self._internal_sections:
+            if sectionName in self._internal_components:
+                result += "config.component_(\'%s\')\n" % sectionName
+            elif sectionName in self._internal_webapps:
+                result += "config.webapp_(\'%s\')\n" % sectionName
+            else:
+                result += "config.section_(\'%s\')\n" % sectionName
+
+            sectionRef = getattr(self, sectionName)
+            for sectionAttr in sectionRef.pythonise_(
+                    document=document, comment=comment):
+                if sectionAttr.startswith("#"):
+                    result += "%s\n" % sectionAttr
+                else:
+                    result += "config.%s\n" % sectionAttr
+
+        return result
+
+    def __str__(self):
+        """
+        string format of this object
+
+        """
+        return self.pythonise_()
+
+    def documentedString_(self):
+        """
+        python format with document_ calls
+        """
+        return self.pythonise_(document=True)
+
+    def commentedString_(self):
+        """
+        python format with docs as comments
+        """
+        return self.pythonise_(comment=True)
+
+
+class ConfigurationEx(Configuration):
+    """
+    _Configuration_
+
+    Top level extended configuration object
+
+    Allows to freely set parameters of the configuration. Things like callables
+    can be used as configuration parameters now. Drawback is that the configuration
+    cannot be saved and passed around using the code.
+    """
+
+    def __init__(self):
+        # super(ConfigurationEx, self).__init__()
+        Configuration.__init__(self)
+
+    def section_(self, sectionName):
+        """
+        _section_
+
+        Get a section by name, create it if not present,
+        and set the skipChecks flag
+        returns a ConfigSection instance
+
+        """
+        section = Configuration.section_(self, sectionName)
+        section._internal_skipChecks = True  # pylint: disable=protected-access
+        return section
+
+
+def loadConfigurationFile(filename):
+    """
+    _loadConfigurationFile_
+
+    Load a Configuration File
+
+    """
+
+    cfgBaseName = os.path.basename(filename).replace(".py", "")
+    cfgDirName = os.path.dirname(filename)
+    if not cfgDirName:
+        modPath = imp.find_module(cfgBaseName)
+    else:
+        modPath = imp.find_module(cfgBaseName, [cfgDirName])
+    try:
+        modRef = imp.load_module(cfgBaseName, modPath[0],
+                                 modPath[1], modPath[2])
+    except Exception as ex:
+        msg = "Unable to load Configuration File:\n"
+        msg += "%s\n" % filename
+        msg += "Due to error:\n"
+        msg += str(ex)
+        msg += str(traceback.format_exc())
+        raise RuntimeError(msg)
+
+    for attr in modRef.__dict__.values():
+        if isinstance(attr, Configuration):
+            return attr
+
+    # //
+    # //  couldnt find a Configuration instance
+    # //
+    msg = "Unable to find a Configuration object instance in file:\n"
+    msg += "%s\n" % filename
+    raise RuntimeError(msg)
+
+
+def saveConfigurationFile(configInstance, filename, **options):
+    """
+    _saveConfigurationFile_
+
+    Save the configuration as a python module
+    Options controls the format of documentation
+
+    comment = True means save docs as comments
+    document = True means save docs as document_ calls
+
+
+    """
+    if isinstance(configInstance, ConfigurationEx):
+        raise NotImplementedError("ConfigurationEx instances cannot be saved. Use Configuration instead.")
+    comment = options.get("comment", False)
+    document = options.get("document", False)
+    if document:
+        comment = False
+
+    with open(filename, 'w') as handle:
+        if document:
+            handle.write(configInstance.documentedString_())
+        elif comment:
+            handle.write(configInstance.commentedString_())
+        else:
+            handle.write(str(configInstance))
+
+    return
+

--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -7,7 +7,7 @@ import logging
 import traceback
 
 ## WMCore dependencies
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 from WMCore.DataStructs.LumiList import LumiList
 
 ## CRAB dependencies

--- a/test/data/TestConfig.py
+++ b/test/data/TestConfig.py
@@ -2,7 +2,7 @@
 This is a test example of configuration file for CRAB-3 client
 """
 
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 import os
 
 config = Configuration()

--- a/test/python/CRABClient_t/Client_t.py
+++ b/test/python/CRABClient_t/Client_t.py
@@ -4,7 +4,7 @@
 Client_t.py
 """
 
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 import os
 import unittest
 import logging

--- a/test/python/CRABClient_t/Commands_t/Commands_t.py
+++ b/test/python/CRABClient_t/Commands_t/Commands_t.py
@@ -1,6 +1,6 @@
 import CRABRESTModelMock
 from FakeRESTServer import FakeRESTServer
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 from CRABClient.Commands.server_info import server_info
 from CRABClient.Commands.getoutput import getoutput
 from CRABClient.Commands.publish import publish

--- a/test/python/CRABClient_t/JobType_t/CMSSWConfig_t.py
+++ b/test/python/CRABClient_t/JobType_t/CMSSWConfig_t.py
@@ -12,7 +12,7 @@ import unittest
 
 from CRABClient.JobType.CMSSWConfig import CMSSWConfig
 from CRABClient.JobType.ScramEnvironment import ScramEnvironment
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 
 #### Test WMCore.Configuration
 

--- a/test/python/CRABClient_t/JobType_t/UserTarball_t.py
+++ b/test/python/CRABClient_t/JobType_t/UserTarball_t.py
@@ -13,7 +13,7 @@ import tarfile
 import unittest
 
 from CRABClient.JobType.UserTarball import UserTarball
-from WMCore.Configuration import Configuration
+from CRABClient.Configuration import Configuration
 from CRABClient.ClientExceptions import InputFileNotFoundException
 
 testWMConfig = Configuration()


### PR DESCRIPTION
move `WMCore` Configuration to `CRABClient` repo. 

Currently entire configuration is moved as is here: https://github.com/dmwm/WMCore/blob/4ec90a8d7f2e1902e37003f9391252cab43f08bc/src/python/WMCore/Configuration.py . Via separate commit/PR I will remove configuration code which is not needed for CRAB. 