### PR TITLE
improve HTTP header parsing

### DIFF
--- a/bin/crab.py
+++ b/bin/crab.py
@@ -149,11 +149,11 @@ if __name__ == "__main__":
         client()
         exitcode = 0 #no exceptions no errors
     except RESTInterfaceException as err:
+        exitcode=err.exitcode
         client.logger.info("The server answered with an error.")
         client.logger.debug("")
         err = str(err)
-        exitcode = int(re.findall(r'(?<=\<\sHTTP/1.1\s)[^\n\s]*', err)[-1])
-        if exitcode==503 and ("CMSWEB Error: Service unavailable") in err:
+        if ("CMSWEB Error: Service unavailable") in err:
             client.logger.info(schedInterv)
         if 'X-Error-Detail' in err:
             errorDetail = re.search(r'(?<=X-Error-Detail:\s)[^\n]*', err).group(0)


### PR DESCRIPTION
brings two changes/improvements:
1. bin/crab.py: remove check if `exitcode==503` as this is repetitive and saves us from parsing response header which is already done in CrabRestInterface.py
2. CrabRestInterface.py: reuse example from WMCore pycurl_manager how to parse HTTP response header to get HTTP code. also, now regex used in this parsing is compatible both with the header return by curl and gocurl.

tested on CMSSW_7_6_7, CMSSW_10_2_6, CMSSW_12_0_1

@belforte these are last changes that i would like to merge before creating new tag and updating IB.