### PR TITLE
add gocurl option

### DIFF
--- a/src/python/CRABClient/CrabRestInterface.py
+++ b/src/python/CRABClient/CrabRestInterface.py
@@ -174,14 +174,27 @@ class HTTPRequests(dict):
             url = url + '?' + data
 
         command = ''
-        command += 'curl -v -X {0}'.format(verb)
-        command += ' -H "User-Agent: %s/%s"' % (self['userAgent'], self['version'])
-        command += ' -H "Accept: */*"'
-        command += ' --data @%s' % path
-        command += ' --cert "%s"' % self['cert']
-        command += ' --key "%s"' % self['key']
-        command += ' --capath "%s"' % caCertPath
-        command += ' "%s" | tee /dev/stderr ' % url
+
+        # CRAB_useGoCurl env. variable is used to define how request should be executed
+        # If variable is set, then goCurl is used for command execution: https://github.com/vkuznet/gocurl
+        if os.getenv('CRAB_useGoCurl'):
+            command += '/cvmfs/cms.cern.ch/cmsmon/gocurl -verbose 2 -method {0}'.format(verb)
+            command += ' -header "User-Agent: %s/%s"' % (self['userAgent'], self['version'])
+            command += ' -header "Accept: */*"'
+            command += ' -data "%s"' % data
+            command += ' -cert "%s"' % self['cert']
+            command += ' -key "%s"' % self['key']
+            command += ' -capath "%s"' % caCertPath
+            command += ' -url "%s" | tee /dev/stderr ' % url
+        else:
+            command += 'curl -v -X {0}'.format(verb)
+            command += ' -H "User-Agent: %s/%s"' % (self['userAgent'], self['version'])
+            command += ' -H "Accept: */*"'
+            command += ' --data @%s' % path
+            command += ' --cert "%s"' % self['cert']
+            command += ' --key "%s"' % self['key']
+            command += ' --capath "%s"' % caCertPath
+            command += ' "%s" | tee /dev/stderr ' % url
 
         # retries this up at least 3 times, or up to self['retry'] times for range of exit codes
         # retries are counted AFTER 1st try, so call is made up to nRetries+1 times !

--- a/src/python/CRABClient/CrabRestInterface.py
+++ b/src/python/CRABClient/CrabRestInterface.py
@@ -177,6 +177,7 @@ class HTTPRequests(dict):
 
         # CRAB_useGoCurl env. variable is used to define how request should be executed
         # If variable is set, then goCurl is used for command execution: https://github.com/vkuznet/gocurl
+        # Same variable is also used inside CRABServer, we should keep name changes (if any) synchronized
         if os.getenv('CRAB_useGoCurl'):
             command += '/cvmfs/cms.cern.ch/cmsmon/gocurl -verbose 2 -method {0}'.format(verb)
             command += ' -header "User-Agent: %s/%s"' % (self['userAgent'], self['version'])

--- a/src/python/CRABClient/CrabRestInterface.py
+++ b/src/python/CRABClient/CrabRestInterface.py
@@ -182,7 +182,7 @@ class HTTPRequests(dict):
             command += '/cvmfs/cms.cern.ch/cmsmon/gocurl -verbose 2 -method {0}'.format(verb)
             command += ' -header "User-Agent: %s/%s"' % (self['userAgent'], self['version'])
             command += ' -header "Accept: */*"'
-            command += ' -data "%s"' % data
+            command += ' -data "@%s"' % path
             command += ' -cert "%s"' % self['cert']
             command += ' -key "%s"' % self['key']
             command += ' -capath "%s"' % caCertPath


### PR DESCRIPTION
currently it does not work because of the issue with gocurl. There is something wrong with capath variable and trying to execute command ends up with bunch of messages like this:
```
[ddirmait@lxplus768 crab_tasks]$ /cvmfs/cms.cern.ch/cmsmon/gocurl -verbose 2 -method GET -header "User-Agent: CRABClient/development" -header "Accept: */*" -data "subresource=delegatedn" -cert "/tmp/x509up_u93401" -key "/tmp/x509up_u93401" -capath "/etc/grid-security/certificates/" -url "https://cmsweb-testbed.cern.ch:8443/crabserver/preprod/info?subresource=delegatedn" | tee /dev/stderr
<...>
2021/11/30 14:39:36 main.go:231: invalid PEM format while importing trust-chain: "/etc/grid-security/certificates//036b3363.namespaces"
2021/11/30 14:39:36 main.go:231: invalid PEM format while importing trust-chain: "/etc/grid-security/certificates//036b3363.r0"
<...>
```

need to open issue in https://github.com/vkuznet/gocurl