### PR TITLE
Do not b64-encode the custom killwarning message

### DIFF
--- a/src/python/CRABClient/Commands/kill.py
+++ b/src/python/CRABClient/Commands/kill.py
@@ -8,8 +8,6 @@ if sys.version_info >= (3, 0):
 if sys.version_info < (3, 0):
     from urllib import urlencode
 
-from base64 import b64encode
-
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.ClientExceptions import RESTCommunicationException
 
@@ -26,7 +24,7 @@ class kill(SubCommand):
         self.logger.debug("Killing task %s" % self.cachedinfo['RequestName'])
         inputs = {'workflow' : self.cachedinfo['RequestName']}
         if self.options.killwarning:
-            inputs.update({'killwarning' : b64encode(self.options.killwarning.encode('utf-8'))})
+            inputs.update({'killwarning' : self.options.killwarning})
 
         dictresult, status, reason = server.delete(api=self.defaultApi, data=urlencode(inputs))
         self.logger.debug("Result: %s" % dictresult)


### PR DESCRIPTION
This PR is required to adapt crabclient to https://github.com/dmwm/CRABServer/pull/7106

### status

Successfully tested in preprod, where I run a REST with changes from `CRABServer/#7106`, see this https://github.com/dmwm/CRABServer/pull/7106#issuecomment-1064209192

### description

This is requied, otherwise after deploying crabserver 7106, we save b64encoded strings in the oracle db (it is not a problem, it is just not user-friendly), see this https://github.com/dmwm/CRABServer/pull/7106#issuecomment-1064171115.

### Mitigation

 if this PR is deployed in supersync with crabserver and we end up with b64-encoded data inside the DB

```plaintext

> crab status -d crab_projects/crab_20220310_161246                                    
CRAB project directory:         /afs/cern.ch/user/d/dmapelli/crab/submit/analysis-data/crab_projects/crab_20220310_161246
Task name:                      220310_151250:dmapelli_crab_20220310_161246
Grid scheduler - Task Worker:   crab3@vocms0121.cern.ch - crab-preprod-tw01
Status on the CRAB server:      NEW on command KILL
Task URL to use for HELP:       https://cmsweb-testbed.cern.ch/crabserver/ui/task/220310_151250%3Admapelli_crab_20220310_161246
Dashboard monitoring URL:       https://monit-grafana.cern.ch/d/cmsTMDetail/cms-task-monitoring-task-view?orgId=11&var-user=dmapelli&var-task=220310_151250%3Admapelli_crab_20220310_161246&from=1646921570000&to=now
Warning:                        The following sites from the user site whitelist are blacklisted by the CRAB server: ['T2_IT_Pisa', 'T2_FR_GRIF_IRFU', 'T2_US_Nebraska', 'T2_UK_SGrid_Bristol']. Since the CRAB server blacklist has precedence, these sites are not considered in the user whitelist.
Warning:                        The following sites appear in both the user site blacklist and whitelist: ['T2_ES_IFCA']. Since the whitelist has precedence, these sites are not considered in the blacklist.
Warning:                        dGVzdCBraWxsd2FybmluZyBtZXNzYWdl         # THIS SHOULD BE  "test killwarning message"
Task bootstrapped at 2022-03-10 15:13:08 UTC. 17 seconds ago
Status information will be available within a few minutes
```

we can decode it in the terminal with
```
> echo dGVzdCBraWxsd2FybmluZyBtZXNzYWdl | base64 -d 
test killwarning message% 
```

