### PR TITLE
checkwrite - adapt to rucio 1.29 api

### DIFF
--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -179,7 +179,7 @@ from rucio.client import Client
 client = Client()
 rse = "{site}"
 lfn = ["user.{username}:{lfn}"]
-for operation in ['third_party_copy', 'write', 'read']:
+for operation in ['write', 'read']:
     try:
         #print('Try Rucio lfn2pn with operation %s', operation)
         out = client.lfns2pfns(rse, lfn, operation=operation)

--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -179,7 +179,7 @@ from rucio.client import Client
 client = Client()
 rse = "{site}"
 lfn = ["user.{username}:{lfn}"]
-for operation in ['write', 'read']:
+for operation in ['third_party_copy_write', 'write', 'read']:
     try:
         #print('Try Rucio lfn2pn with operation %s', operation)
         out = client.lfns2pfns(rse, lfn, operation=operation)


### PR DESCRIPTION
This was requested in https://github.com/dmwm/CRABServer/issues/7364#issuecomment-1219350157

### description

Without this PR, `crab checkwrite` fails with

```plaintext
> crab checkwrite --checksum=yes --site=T2_IT_Pisa
Will check write permission in the default location /store/user/<username>
Validating LFN /store/user/dmapelli...
LFN /store/user/dmapelli is valid.
Will use `gfal-copy`, `gfal-rm` commands for checking write permissions
Will check write permission in /store/user/dmapelli on site T2_IT_Pisa
Will use PFN: Failed to resolve LNF to PFN via Rucio. Error is:
 RSE does not support requested operation.
Details: Operation third_party_copy is not supported
srm://stormfe1.pi.infn.it:8444/srm/managerv2?SFN=/cms/store/user/dmapelli/crab3checkwrite_20220819_085201/crab3checkwrite_20220819_085201.tmp
```

This is caused by the rucio upgrade to v1.29.

With this PR, `checkwrite` works again as expected [1].

### more info

<details><summary>[1]</summary>

```plaintext
> crab checkwrite --checksum=yes --site=T2_IT_Pisa
Will check write permission in the default location /store/user/<username>
Validating LFN /store/user/dmapelli...
LFN /store/user/dmapelli is valid.
Will use `gfal-copy`, `gfal-rm` commands for checking write permissions
Will check write permission in /store/user/dmapelli on site T2_IT_Pisa
Will use PFN: davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/crab3checkwrite_20220819_095238.tmp

Attempting to create (dummy) directory crab3checkwrite_20220819_095238 and copy (dummy) file crab3checkwrite_20220819_095238.tmp to /store/user/dmapelli

Executing command: which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`; gfal-copy -p -v -t 180 -K ADLER32 file:///afs/cern.ch/user/d/dmapelli/crab/client/crab3checkwrite_20220819_095238.tmp 'davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/crab3checkwrite_20220819_095238.tmp'
Please wait...

Successfully created directory crab3checkwrite_20220819_095238 and copied file crab3checkwrite_20220819_095238.tmp to /store/user/dmapelli

Attempting to delete file davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/crab3checkwrite_20220819_095238.tmp

Executing command: which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`; gfal-rm -v -t 180 'davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/crab3checkwrite_20220819_095238.tmp'
Please wait...

Successfully deleted file davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/crab3checkwrite_20220819_095238.tmp

Attempting to delete directory davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/

Executing command: which scram >/dev/null 2>&1 && eval `scram unsetenv -sh`; gfal-rm -r -v -t 180 'davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/'
Please wait...

Successfully deleted directory davs://stwebdav.pi.infn.it:8443/cms/store/user/dmapelli/crab3checkwrite_20220819_095238/

Checkwrite Result:
Success: Able to write in /store/user/dmapelli on site T2_IT_Pisa
```
</details>