### PR TITLE
new Site.acceleratorParams

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -53,6 +53,7 @@ parametersMapping = {
                   'sitewhitelist'  : {'default': None,       'config': ['Site.whitelist'],                  'type': 'ListType',    'required': False},
                   'siteblacklist'  : {'default': None,       'config': ['Site.blacklist'],                  'type': 'ListType',    'required': False},
                   'requireaccelerator' : {'default': False,  'config': ['Site.requireAccelerator'],         'type': 'BooleanType', 'required': False},
+                  'acceleratorparams'  : {'default': None,   'config': ['Site.acceleratorParams'],          'type': 'DictType',    'required': False},
                   'vorole'         : {'default': None,       'config': ['User.voRole'],                     'type': 'StringType',  'required': False},
                   'vogroup'        : {'default': None,       'config': ['User.voGroup'],                    'type': 'StringType',  'required': False},
                   'oneEventMode'   : {'default': False,      'config': ['Debug.oneEventMode'],              'type': 'BooleanType', 'required': False},

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -90,6 +90,8 @@ class submit(SubCommand):
                     self.configreq[param] = self.configreq[param].rstrip('/')
             elif param == 'scriptexe' and 'scriptexe' in self.configreq:
                 self.configreq[param] = os.path.basename(self.configreq[param])
+            elif param in ['acceleratorparams']:
+                self.configreq[param] = json.dumps(self.configreq[param])
 
         jobconfig = {}
         #get the backend URLs from the server external configuration

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -90,7 +90,7 @@ class submit(SubCommand):
                     self.configreq[param] = self.configreq[param].rstrip('/')
             elif param == 'scriptexe' and 'scriptexe' in self.configreq:
                 self.configreq[param] = os.path.basename(self.configreq[param])
-            elif param in ['acceleratorparams']:
+            elif param in ['acceleratorparams'] and param in self.configreq:
                 self.configreq[param] = json.dumps(self.configreq[param])
 
         jobconfig = {}


### PR DESCRIPTION
Part of https://github.com/dmwm/CRABServer/issues/6989
Server side: https://github.com/dmwm/CRABServer/pull/7470

Add `Site.acceleratorParams` to allow user send GPU parameters as key/value.
Serializing dict to JSON string and sending it to the server. Only validate key/value on server's side.

Configuration Example:
```python
config.Site.requireAccelerator = True
config.Site.acceleratorParams = {
    "CUDACapabilities": ["6.0", "6.1", "6.2", "7.0", "7.2", "7.5", "8.0", "8.6"],
    "CUDARuntime": "11.4",
    "GPUMemoryMB": 8000
}
```