### PR TITLE
adapt CRABClient to new jobwrapper

### DIFF
--- a/src/python/CRABClient/Commands/preparelocal.py
+++ b/src/python/CRABClient/Commands/preparelocal.py
@@ -130,7 +130,7 @@ class preparelocal(SubCommand):
 
         self.logger.debug("Creating InputArgs.txt file")
         inputArgsStr = "-a %(CRAB_Archive)s --sourceURL=%(CRAB_ISB)s --jobNumber=%(CRAB_Id)s --cmsswVersion=%(CRAB_JobSW)s --scramArch=%(CRAB_JobArch)s --inputFile=%(inputFiles)s --runAndLumis=%(runAndLumiMask)s --lheInputFiles=%(lheInputFiles)s --firstEvent=%(firstEvent)s --firstLumi=%(firstLumi)s --lastEvent=%(lastEvent)s --firstRun=%(firstRun)s --seeding=%(seeding)s --scriptExe=%(scriptExe)s --eventsPerLumi=%(eventsPerLumi)s --maxRuntime=%(maxRuntime)s --scriptArgs=%(scriptArgs)s -o %(CRAB_AdditionalOutputFiles)s\n"
-        for f in ["gWMS-CMSRunAnalysis.sh", "CMSRunAnalysis.sh", "cmscp.py", "CMSRunAnalysis.tar.gz",
+        for f in ["gWMS-CMSRunAnalysis.sh", "submit_env.sh", "CMSRunAnalysis.sh", "cmscp.py", "CMSRunAnalysis.tar.gz",
                   "sandbox.tar.gz", "run_and_lumis.tar.gz", "input_files.tar.gz", "Job.submit"]:
             shutil.copy2(f, targetDir)
         with open(os.path.join(targetDir, "InputArgs.txt"), "w") as fd:
@@ -144,8 +144,9 @@ class preparelocal(SubCommand):
         #We check the X509_USER_PROXY variable is set  otherwise stageout fails
         #The "tar xzmf CMSRunAnalysis.tar.gz" is needed because in CRAB3_RUNTIME_DEBUG mode the file is not unpacked (why?)
         #Job.submit is also modified to set some things that are condor macro expanded during submission (needed by cmscp)
-        bashWrapper = """export SCRAM_ARCH=slc6_amd64_gcc481; export CRAB_RUNTIME_TARBALL=local; export CRAB_TASKMANAGER_TARBALL=local; export _CONDOR_JOB_AD=Job.${1}.submit
-export CRAB3_RUNTIME_DEBUG=True
+        bashWrapper = """#!/bin/bash
+. submit_env.sh && save_env && setup_local_env
+export _CONDOR_JOB_AD=Job.${1}.submit
 tar xzmf CMSRunAnalysis.tar.gz
 cp Job.submit Job.${1}.submit
 """

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -384,7 +384,7 @@ class submit(SubCommand):
                 tf = tarfile.open(os.path.join(tmpDir, name))
                 tf.extractall(tmpDir)
                 tf.close()
-            os.environ.update({'CRAB3_RUNTIME_DEBUG': 'True', '_CONDOR_JOB_AD': 'Job.submit'})
+            os.environ.update({'_CONDOR_JOB_AD': 'Job.submit'})
 
             with open('splitting-summary.json') as f:
                 splitting = json.load(f)
@@ -407,7 +407,8 @@ class submit(SubCommand):
                 # inside the environemnt where CRABClient runs (i.e. some CMSSW env. which may conflict
                 # with the WMCore code used in the wrapper
                 undoScram = "eval `scram unsetenv -sh`; "
-                command = undoScram + 'sh CMSRunAnalysis.sh ' + opts
+                setEnv = "echo $PWD && ls -lrth && . ./submit_env.sh && save_env && setup_local_env; "
+                command = undoScram + setEnv + 'sh CMSRunAnalysis.sh ' + opts
                 out, err, returncode = execute_command(command=command)
                 self.logger.debug(out)
                 if returncode != 0:

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -407,7 +407,24 @@ class submit(SubCommand):
                 # inside the environemnt where CRABClient runs (i.e. some CMSSW env. which may conflict
                 # with the WMCore code used in the wrapper
                 undoScram = "eval `scram unsetenv -sh`; "
-                setEnv = "echo $PWD && ls -lrth && . ./submit_env.sh && save_env && setup_local_env; "
+                setEnv = """
+echo $PWD && ls -lrth 
+if [ -f ./submit_env.sh ]; then
+    # (dario, 202212)
+    # this if/else has been introduced only for backwards compatibility of the crab client
+    # with the old TW with the old jobwrapper.
+    # once the new TW with the new jobwrapper is deployed, we can remove this
+    # if/else and keep only the code inside the "if" clause.
+    . ./submit_env.sh && save_env && setup_local_env; 
+else
+    # this code in the "else" clause can be discarded after we merge the new
+    # TW with the new jobwrapper.
+    export SCRAM_ARCH=slc6_amd64_gcc481
+    export CRAB_RUNTIME_TARBALL=local
+    export CRAB_TASKMANAGER_TARBALL=local
+    export CRAB3_RUNTIME_DEBUG=True
+fi
+"""
                 command = undoScram + setEnv + 'sh CMSRunAnalysis.sh ' + opts
                 out, err, returncode = execute_command(command=command)
                 self.logger.debug(out)


### PR DESCRIPTION
We need to update crab client `submit --dryrun` and `preparelocal` commands to match the new file structure introduced with https://github.com/dmwm/CRABServer/releases/tag/v3.221128 (new job wrapper)