### PR TITLE
submit --dryrun. print info about last trial

### DIFF
--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -400,6 +400,8 @@ class submit(SubCommand):
             totalJobSeconds = 0
             maxSeconds = 25
             while totalJobSeconds < maxSeconds:
+                if totalJobSeconds != 0:
+                    self.logger.info("Last trial took only %.1f seconds. We are trying now with %.0f events", totalJobSeconds, events)
                 optsList = getCMSRunAnalysisOpts('Job.submit', 'RunJobs.dag', job=1, events=events)
                 # from a python list to a string which can be used as shell command argument
                 opts = ''


### PR DESCRIPTION
Related to https://github.com/dmwm/CRABServer/issues/7493 

### status

tested

### description

submit --dryrun needs to run for at least 25s in order not to make its estimates based on very few small events. If the first dryrun attempt is too short, the same cmsRun command is called again, with an increasing number of events. with this commit, every trial reports how long it took and how many events the next trial will process.

As suggested by stefano in https://github.com/dmwm/CRABServer/issues/7493#issuecomment-1398722319, we have

```plaintext
> crab submit --dryrun
[...]
Please wait...
Task status: UPLOADED

Created temporary directory for dry run sandbox in /tmp/dmapelli/tmpp3ytfqpx
Executing test, please wait...
Last trial took only 17.4 seconds. We are trying now with 7985 events
Last trial took only 14.0 seconds. We are trying now with 15556 events
Last trial took only 13.9 seconds. We are trying now with 26811 events
^CKeyboard Interrupted
Log file is [...]/crab.log
```

(nb: in the test above I am using skipEvents to process only 300 events at each run, which is why the runtime does not increase at every new trial.)