### PR TITLE
new Data.inputBlocks parameter

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -62,6 +62,7 @@ parametersMapping = {
                   'collector'      : {'default': None,       'config': ['Debug.collector'],                 'type': 'StringType',  'required': False},
                   'ignoreglobalblacklist':{'default': False, 'config': ['Site.ignoreGlobalBlacklist'],      'type': 'BooleanType', 'required': False},
                   'partialdataset' : {'default': False,      'config': ['Data.partialDataset'],             'type': 'BooleanType', 'required': False},
+                  'inputblocks'    : {'default': [],         'config': ['Data.inputBlocks'],                'type': 'ListType',    'required': False},
                  },
     'other-config-params': [         {'default': None,       'config': ['General.workArea'],                'type': 'StringType',  'required': False},
                                      {'default': 'prod',     'config': ['General.instance'],                'type': 'StringType',  'required': True },

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -126,7 +126,8 @@ class submit(SubCommand):
         self.logger.debug("Submitting %s " % str(self.configreq))
         ## TODO: this shouldn't be hard-coded.
         listParams = ['addoutputfiles', 'sitewhitelist', 'siteblacklist', 'blockwhitelist', 'blockblacklist', \
-                      'tfileoutfiles', 'edmoutfiles', 'runs', 'lumis', 'userfiles', 'scriptargs', 'extrajdl']
+                      'tfileoutfiles', 'edmoutfiles', 'runs', 'lumis', 'userfiles', 'scriptargs', 'extrajdl', \
+                      'inputblocks']
         self.configreq_encoded = self._encodeRequest(self.configreq, listParams)
         self.logger.debug('Encoded submit request: %s' % (self.configreq_encoded))
 
@@ -412,14 +413,14 @@ class submit(SubCommand):
                 # with the WMCore code used in the wrapper
                 undoScram = "eval `scram unsetenv -sh`; "
                 setEnv = """
-echo $PWD && ls -lrth 
+echo $PWD && ls -lrth
 if [ -f ./submit_env.sh ]; then
     # (dario, 202212)
     # this if/else has been introduced only for backwards compatibility of the crab client
     # with the old TW with the old jobwrapper.
     # once the new TW with the new jobwrapper is deployed, we can remove this
     # if/else and keep only the code inside the "if" clause.
-    . ./submit_env.sh && save_env && setup_local_env; 
+    . ./submit_env.sh && save_env && setup_local_env;
 else
     # this code in the "else" clause can be discarded after we merge the new
     # TW with the new jobwrapper.

--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -247,6 +247,19 @@ class Analysis(BasicJobType):
 
         configArguments['jobtype'] = 'Analysis'
 
+        # append dataset name to block uuid for users
+        if getattr(self.config.Data, 'inputBlocks'):
+            inputBlocks = getattr(self.config.Data, 'inputBlocks')
+            inputDataset = getattr(self.config.Data, 'inputDataset')
+            uuid_regex = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+            all_blocks = []
+            for block in inputBlocks:
+                if uuid_regex.match(block):
+                    all_blocks.append(inputDataset+'#'+block)
+                else:
+                    all_blocks.append(block)
+            configArguments['inputblocks'] = all_blocks
+
         return tarFilename, configArguments
 
     def checkAutomaticAvail(self, allowedSplitAlgos):


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABServer/issues/7203

Client side of https://github.com/dmwm/CRABServer/pull/7525
`Data.inputBlocks` as list of input blocks that users want to processes. 

~~Currrently drafting. We can lets users supply only blocks uuid then we concat its with inputDataset in client side.~~
~~And/or lets user supply full block name but we need to verify if dataset's name in block is same as inputDataset~~

I decide to allow users to provide either full block name or block UUID. 
- If it match UUID format, client will append dataset name for users before sending to server.
- If not, let server report error in case they forget to change dataset name.
