### PR TITLE
Fix getattr with config.Data.inputBlocks

### DIFF
--- a/src/python/CRABClient/JobType/Analysis.py
+++ b/src/python/CRABClient/JobType/Analysis.py
@@ -248,7 +248,7 @@ class Analysis(BasicJobType):
         configArguments['jobtype'] = 'Analysis'
 
         # append dataset name to block uuid for users
-        if getattr(self.config.Data, 'inputBlocks'):
+        if getattr(self.config.Data, 'inputBlocks', None):
             inputBlocks = getattr(self.config.Data, 'inputBlocks')
             inputDataset = getattr(self.config.Data, 'inputDataset')
             uuid_regex = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')


### PR DESCRIPTION
Fix PR https://github.com/dmwm/CRABClient/pull/5185

I misunderstand [getattr()](https://docs.python.org/3/library/functions.html#getattr) with [dict.get()](https://docs.python.org/3/library/stdtypes.html#dict.get) by assuming `getattr()` will automatically return `None` if we do not provide a default value when calling the function.
