### PR TITLE
add src/**/python to user sandbox

### DIFF
--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -160,7 +160,7 @@ class UserTarball(object):
         # Note that dataDirs are only looked-for and added under the src/ folder.
         # /data/ subdirs contain data files needed by the code
         # /interface/ subdirs contain C++ header files needed e.g. by ROOT6
-        dataDirs = ['data', 'interface']
+        dataDirs = ['data', 'interface', 'python']
         userFiles = userFiles or []
 
         # Tar up whole directories

--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -145,6 +145,8 @@ class UserTarball(object):
         """
         Add the necessary files to the tarball
         """
+
+        # Tar up whole directories in $CMSSW_BASE/
         directories = ['lib', 'biglib', 'module']
         if getattr(self.config.JobType, 'sendPythonFolder', configParametersInfo['JobType.sendPythonFolder']['default']):
             directories.append('python')
@@ -157,13 +159,6 @@ class UserTarball(object):
                 self.logger.info("The config.JobType.sendExternalFolder parameter is set to True but the external directory "\
                                   "doesn't exist or is empty, not adding to tarball. Path: %s" % externalDirPath)
 
-        # Note that dataDirs are only looked-for and added under the src/ folder.
-        # /data/ subdirs contain data files needed by the code
-        # /interface/ subdirs contain C++ header files needed e.g. by ROOT6
-        dataDirs = ['data', 'interface', 'python']
-        userFiles = userFiles or []
-
-        # Tar up whole directories
         for directory in directories:
             fullPath = os.path.join(self.scram.getCmsswBase(), directory)
             self.logger.debug("Checking directory %s" % fullPath)
@@ -172,16 +167,28 @@ class UserTarball(object):
                 self.checkdirectory(fullPath)
                 self.tarfile.add(fullPath, directory, recursive=True)
 
-        # Search for and tar up "data" directories in src/
+        # Recursively search for and add to tar some directories in $CMSSW_BASE/src/
+        # Note that recursiveDirs are **only** looked-for under the $CMSSW_BASE/src/ folder!
+        # /data/      subdirs contain data files needed by the code
+        # /interface/ subdirs contain C++ header files needed e.g. by ROOT6
+        #             Shahzad suggested adding to the sandbox only src/*/*/interface, but
+        #             we currently add all the src/**/interface, see:
+        #             https://cms-talk.web.cern.ch/t/missing-symbolic-links-in-cmssw-base-python/20403/35
+        #             Since we have not found a problem yet, Dario will not change it.
+        # /python/    subdirs contain user python code, see https://github.com/dmwm/CRABClient/issues/5187
+        #             Shahzad asked that we add to the tar only src/*/*/python, but we tar all the src/**/python
+        #             this is because Dario preferred to re-use existing code for /data/ and /interface/
+        recursiveDirs = ['data', 'interface', 'python']
         srcPath = os.path.join(self.scram.getCmsswBase(), 'src')
         for root, _, _ in os.walk(srcPath):
-            if os.path.basename(root) in dataDirs:
+            if os.path.basename(root) in recursiveDirs:
                 directory = root.replace(srcPath, 'src')
                 self.logger.debug("Adding data directory %s to tarball" % root)
                 self.checkdirectory(root)
                 self.tarfile.add(root, directory, recursive=True)
 
         # Tar up extra files the user needs
+        userFiles = userFiles or []
         for globName in userFiles:
             fileNames = glob.glob(globName)
             if not fileNames:


### PR DESCRIPTION
Fixes #5187

### status

tested:

- [x]  https://cmsweb-test11.cern.ch/crabserver/ui/task/230217_111711%3Admapelli_crab_20230217_121708

### description

This PR simply adds to the sandbox all the `python`  directories that are recursively found under `$CMSSW_BASE/src`. 

I have two questions for @belforte :

- [x] should we clean the comments and variable names? I mean, if we send the `python` directories maybe we should stop referring to those directories as "data". this is just cosmetic, i am not even sure i am willing to risk renaming variables and comments more than necessary
- [x] should we stop supporting the `Jobtype.sendPythonFolder` option? I am not sure how much this change makes it irrelevant. Maybe this is more for cmssw people to decide