### PR TITLE
Print rule id instead of container name in "crab status" command

### DIFF
--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -236,15 +236,18 @@ class status(SubCommand):
         usingRucio = outputLfn.startswith('/store/user/rucio')
         if usingRucio:
             ruleID = None
-            data = {'subresource':'getTransferStatus', 'taskname':taskname, 'username': user}
+            data = {'subresource': 'getTransferStatus', 'taskname': taskname, 'username': user}
             filetransferinfo, _, _ = server.get(api='fileusertransfers', data=data)
             index = filetransferinfo['desc']['columns'].index('tm_fts_id')
             for xfer in filetransferinfo['result']:
-                if xfer[index] != 'NA':
+                # Skip tm_fts_id contains null or 'NA'.
+                if xfer[index] == 'NA' or not xfer[index]:
+                    continue
+                else:
                     ruleID = xfer[index]
                     break
             if ruleID:
-                container = { 'ruleID': ruleID }
+                container = {'ruleID': ruleID}
             else:
                 container = None
         else:
@@ -1017,7 +1020,7 @@ class status(SubCommand):
         if not container:
             return
         msg=""
-        msg += "\nRucio transfer container's rule: https://cms-rucio-webui.cern.ch/rule?rule_id=%s" % (container['ruleID'])
+        msg += "\nTransfer container's rule: https://cms-rucio-webui.cern.ch/rule?rule_id=%s" % (container['ruleID'])
         msg += "\nTips on how to check on Rucio StageOut at https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#Stageout_with_Rucio "
         self.logger.info(msg)
 


### PR DESCRIPTION
Sub task of https://github.com/dmwm/CRABServer/issues/7797

(See the line after `Job status:`) Changing from 

![Screenshot from 2023-08-08 13-18-09](https://github.com/dmwm/CRABClient/assets/2346664/676cca0c-aef5-4474-88e8-635cdc34b19b)

```
Rucio Container:  user.tseethon:/GenericTTbar/tseethon-ruciotransfers-1-94ba0e06145abd65ccb1d21786dc7e1d/USER
Tips on how to check on Rucio StageOut at https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#Stageout_with_Rucio 
```

To 

![Screenshot from 2023-08-08 15-16-15](https://github.com/dmwm/CRABClient/assets/2346664/25e62d85-b9ef-414f-8153-0a59479dc601)

```
Transfer container's rule: https://cms-rucio-webui.cern.ch/rule?rule_id=5dd94c3731994a8f8251571a7f5aab9c
Tips on how to check on Rucio StageOut at https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#Stageout_with_Rucio 
```