### PR TITLE
avoid rucio setup getting confused by existing CMSSW stuff

### DIFF
--- a/bin/rucio_env.sh
+++ b/bin/rucio_env.sh
@@ -2,5 +2,6 @@
 # returns the two env. variables needed to make Rucio client work
 # on the current OS
 unset PYTHONPATH
+eval `scram unsetenv -sh`
 source /cvmfs/cms.cern.ch/rucio/setup-py3.sh > /dev/null
 echo $RUCIO_HOME $PYTHONPATH


### PR DESCRIPTION
if one has CMSSW setup for a different arch than the current machine (e.g. do cmsrel on SL7 and than run on SL8, which works) the `/cvmfs/cms.cern.ch/rucio/setup-py3.sh` will get confused and fail to resolve dependencies.
This PR makes sure that Rucio is setup in the pre-cmsenv environment.