### PR TITLE
Use isEnoughRucioQuota from ServerUtilities.py

### DIFF
--- a/src/python/CRABClient/ClientExceptions.py
+++ b/src/python/CRABClient/ClientExceptions.py
@@ -101,3 +101,9 @@ class RESTInterfaceException(ClientException):
     Errors coming from interaction with REST interface
     """
     exitcode = 3016
+
+class RucioClientException(ClientException):
+    """
+    Errors coming from interaction with REST interface
+    """
+    exitcode = 3017

--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -797,3 +797,32 @@ def execute_command(command=None, logger=None, timeout=None, redirect=True):
         logger.debug('output : %s\n error: %s\n retcode : %s' % (stdout, stderr, rc))
 
     return stdout, stderr, rc
+
+def getRucioClientFromLFN(origClient, lfn, logger):
+    """
+    Get appropriate Rucio client with account parsing from LFN.
+
+    :param origClient:
+    :type origClient:
+    :param lfn: LFN
+    :type lfn: str
+    :param logger: logger object
+    :type logger: logging
+
+    :return: rucio client object
+    :rtype: rucio.client.Client
+    """
+    from ServerUtilities import getRucioAccountFromLFN
+    from rucio.client import Client
+    from rucio.common.exception import RucioException
+    account = getRucioAccountFromLFN(lfn)
+    if origClient.account == account:
+        return origClient
+    try:
+        client = Client(account=account)
+        me = client.whoami()
+        logger.debug('Initializing new Rucio client for account %s' % me['account'])
+        return client
+    except RucioException as e:
+        msg = "Cannot initialize Rucio Client."
+        raise RucioClientException(msg) from e

--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -25,7 +25,7 @@ from optparse import OptionValueError
 ## CRAB dependencies
 import CRABClient.Emulator
 from ServerUtilities import uploadToS3, getDownloadUrlFromS3
-from CRABClient.ClientExceptions import ClientException, TaskNotFoundException, CachefileNotFoundException, ConfigurationException, ConfigException, UsernameException, ProxyException, RESTCommunicationException
+from CRABClient.ClientExceptions import ClientException, TaskNotFoundException, CachefileNotFoundException, ConfigurationException, ConfigException, UsernameException, ProxyException, RESTCommunicationException, RucioClientException
 
 # pickle files need to be opeb in different mode in python2 or python3
 if sys.version_info >= (3, 0):
@@ -224,7 +224,7 @@ def uploadlogfile(logger, proxyfilename, taskname=None, logfilename=None, logpat
     if proxyfilename == None:
         logger.debug('No proxy was given')
         doupload = False
-        
+
     if doupload:
         # uploadLog is executed directly from crab main script, does not inherit from SubCommand
         # so it needs its own REST server instantiation
@@ -797,4 +797,3 @@ def execute_command(command=None, logger=None, timeout=None, redirect=True):
         logger.debug('output : %s\n error: %s\n retcode : %s' % (stdout, stderr, rc))
 
     return stdout, stderr, rc
-

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -391,6 +391,8 @@ class SubCommand(ConfigCommand):
         if self.cmdconf['requiresREST']:
             self.logger.debug("Command api %s" %(self.defaultApi))
 
+        self.rucio = None
+
     def serverInstance(self):
         """
         Deriving the correct instance to use and the server url. Client is allowed to propagate the instance name and corresponding url
@@ -603,7 +605,7 @@ class SubCommand(ConfigCommand):
                     self.logger.info('Rucio client intialized for account %s' % me['account'])
                 except RucioException as e:
                     msg = "Cannot initialize Rucio Client. Error: %s" % str(e)
-                    raise RucioClientException(msg)
+                    raise RucioClientException(msg) from e
             else:
                 self.rucio = None
 

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -1,6 +1,6 @@
 import os
 import re
-import imp
+import imp 
 import json
 import types
 from ast import literal_eval
@@ -17,8 +17,7 @@ from CRABClient.CRABOptParser import CRABCmdOptParser
 from CRABClient.CredentialInteractions import CredentialInteractions
 from CRABClient.ClientUtilities import loadCache, getWorkArea, server_info, createWorkArea, execute_command
 from CRABClient.ClientExceptions import (ConfigurationException, MissingOptionException,
-                                         EnvironmentException, CachefileNotFoundException,
-                                         RucioClientException)
+                                         EnvironmentException, CachefileNotFoundException)
 from CRABClient.ClientMapping import (renamedParams, commandsConfiguration, configParametersInfo,
                                       getParamDefaultValue, deprecatedParams)
 from CRABClient.UserUtilities import getUsername
@@ -352,9 +351,9 @@ class SubCommand(ConfigCommand):
         # At this point we check if there is a valid proxy, and
         # eventually create a new one. If the proxy was not created by CRAB, we check that the
         # VO role/group in the proxy are the same as specified by the user in the configuration
-        # file (or in the command line options). If it is not, we ask the user if he wants to
-        # overwrite the current proxy. If he doesn't want to overwrite it, we don't continue
-        # and ask him to provide the VO role/group as in the existing proxy.
+        # file (or in the command line options). If it is not, we ask the user if he wants to 
+        # overwrite the current proxy. If he doesn't want to overwrite it, we don't continue 
+        # and ask him to provide the VO role/group as in the existing proxy. 
         # Finally, delegate the proxy to myproxy server.
         self.handleVomsProxy(proxyOptsSetPlace)
 
@@ -376,6 +375,17 @@ class SubCommand(ConfigCommand):
             self.s3tester.setDbInstance('preprod')
             self.handleMyProxy()
 
+        if self.cmdconf['requiresRucio']:
+            if os.environ.get('RUCIO_HOME', None):
+                username = getUsername(self.proxyfilename, logger=self.logger)
+                from rucio.client import Client
+                os.environ['RUCIO_ACCOUNT'] = username
+                self.rucio = Client()
+                me = self.rucio.whoami()
+                self.logger.info('Rucio client intialized for account %s' % me['account'])
+            else:
+                self.rucio = None
+
         # Validate the command options
         self.validateOptions()
         self.validateOptions()
@@ -391,7 +401,6 @@ class SubCommand(ConfigCommand):
         if self.cmdconf['requiresREST']:
             self.logger.debug("Command api %s" %(self.defaultApi))
 
-        self.rucio = None
 
     def serverInstance(self):
         """
@@ -466,7 +475,7 @@ class SubCommand(ConfigCommand):
         return
 
     def handleMyProxy(self):
-        """
+        """ 
         check myproxy credential and delegate again it if necessary.
         takes no input and returns no output, bur raises exception if delegation failed
         """
@@ -585,29 +594,6 @@ class SubCommand(ConfigCommand):
             with open(crabCacheFileName_tmp, 'w') as fd:
                 json.dump(self.crab3dic, fd)
             os.rename(crabCacheFileName_tmp, crabCacheFileName)
-
-    def initRucioClient(self, lfn):
-        if self.cmdconf['requiresRucio']:
-            if os.environ.get('RUCIO_HOME', None):
-                from ServerUtilities import getRucioAccountFromLFN
-                from rucio.client import Client
-                from rucio.common.exception import RucioException
-                if hasattr(self.options, 'userlfn') and self.options.userlfn is not None\
-                    and (self.options.userlfn.startswith('/store/user/rucio/')
-                         or self.options.userlfn.startswith('/store/group/rucio/')):
-                    account = getRucioAccountFromLFN(self.options.userlfn)
-                else:
-                    account = getUsername(self.proxyfilename, logger=self.logger)
-                os.environ['RUCIO_ACCOUNT'] = account
-                try:
-                    self.rucio = Client()
-                    me = self.rucio.whoami()
-                    self.logger.info('Rucio client intialized for account %s' % me['account'])
-                except RucioException as e:
-                    msg = "Cannot initialize Rucio Client. Error: %s" % str(e)
-                    raise RucioClientException(msg) from e
-            else:
-                self.rucio = None
 
 
     def __call__(self):

--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -243,6 +243,9 @@ exit(0)
         if not self.rucio:
             self.logger.warning("Rucio client not available with this CMSSW version. Can not check")
             return 'FAILED'
+        # We need to switch to group account when needed untils CMS Rucio fix
+        # the permission issue.
+        # See https://mattermost.web.cern.ch/cms-o-and-c/pl/ej7zwkr747rifezzcyyweisx9r
         rucioClient = getRucioClientFromLFN(self.rucio, lfn, self.logger)
         quotaCheck = isEnoughRucioQuota(rucioClient, site)
         if quotaCheck['hasQuota'] and quotaCheck['isEnough']:

--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -36,7 +36,6 @@ class checkwrite(SubCommand):
             self.logger.info('Will check write permission in the default location /store/user/<username>')
             self.lfnPrefix = '/store/user/' + username
 
-        self.initRucioClient(self.lfnPrefix)
         ## Check that the location where we want to check write permission
         ## is one where the user will be allowed to stageout.
         self.logger.info("Validating LFN %s...", self.lfnPrefix)
@@ -266,7 +265,7 @@ exit(0)
 
         # print summary of rucio quota
         msg = "FYI this is your Rucio quota situation (rounded to GBytes = 10^9 Bytes)"
-        quotaRecords = rucioClient.get_local_account_usage(self.rucio.account)
+        quotaRecords = rucioClient.get_local_account_usage(rucioClient.account)
         msg += "\n%20s%10s%10s%10s" % ('Site', 'Quota', 'Used', 'Free')
         for record in quotaRecords:
             site = record['rse']

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -1152,7 +1152,7 @@ class status(SubCommand):
             msg += "\n %sYOU MUST CLEANUP YOUR RUCIO SPACE IMMEDIATELY (remove some rules)%s:" % (colors.RED, colors.NORMAL)
             self.logger.warning(msg)
             return
-        if isQoutaWarning:
+        if isQuotaWarning:
             msg = "%sWarning%s: " % (colors.RED, colors.NORMAL)
             msg += "This may be not enough for your output, leading to problems. Consider cleaning up"
             self.logger.warning(msg)

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -73,8 +73,6 @@ class status(SubCommand):
             outputDatasetList = None
         outDataset = outputDatasetList[0] if outputDatasetList else None # we do not support multiple output datasets anymore
 
-        self.initRucioClient(outputLfn)
-
         #Print information from the database
         self.printTaskInfo(crabDBInfo, user)
         if not rootDagId:

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -18,7 +18,7 @@ if sys.version_info >= (3, 0):
 if sys.version_info < (3, 0):
     from urllib import quote
 
-from CRABClient.ClientUtilities import colors, validateJobids, compareJobids
+from CRABClient.ClientUtilities import (colors, getRucioClientFromLFN, validateJobids, compareJobids)
 from CRABClient.ClientUtilities import PKL_R_MODE
 from CRABClient.UserUtilities import curlGetFileFromURL, getColumn
 from CRABClient.Commands.SubCommand import SubCommand
@@ -239,7 +239,7 @@ class status(SubCommand):
         usingRucio = outputLfn.startswith('/store/user/rucio') or outputLfn.startswith('/store/group/rucio')
 
         if dagStatus != 'COMPLETED' and usingRucio:
-            self.printRucioQuotaInfo(user, outputDestinationSite)
+            self.printRucioQuotaInfo(outputLfn, outputDestinationSite)
 
         container = None
         if usingRucio:
@@ -1135,24 +1135,25 @@ class status(SubCommand):
 
         return pubStatus
 
-    def printRucioQuotaInfo(self, user, site):
+    def printRucioQuotaInfo(self, lfn, site):
         if not self.rucio:
             return
         if site == 'T3_CERN_CERNBOX':
             return
-
-        _, isEnough, isQuotaWarning, quota = isEnoughRucioQuota(self.rucio, site)
-
-        totalGB, _, freeGB = quota
-        print("You have %d/%d GBytes available as Rucio quota at site %s" % (freeGB, totalGB, site))
-        if not isEnough:
+        # We need to switch to group account when needed untils CMS Rucio fix
+        # the permission issue.
+        # See https://mattermost.web.cern.ch/cms-o-and-c/pl/ej7zwkr747rifezzcyyweisx9r
+        rucioClient = getRucioClientFromLFN(self.rucio, lfn, self.logger)
+        quotaCheck = isEnoughRucioQuota(rucioClient, site)
+        self.logger.info("You have %d/%d GBytes available as Rucio quota at site %s" % (quotaCheck['free'], quotaCheck['total'], site))
+        if not quotaCheck['isEnough']:
             msg = "%sALARM: Not enough space at ASO destination %s" % (colors.RED, colors.NORMAL)
             msg += "\n This very dangerous. Your output stageout will get stuck."
             msg += "\n status information will be stale and could be misleading"
             msg += "\n %sYOU MUST CLEANUP YOUR RUCIO SPACE IMMEDIATELY (remove some rules)%s:" % (colors.RED, colors.NORMAL)
             self.logger.warning(msg)
             return
-        if isQuotaWarning:
+        if quotaCheck['isQuotaWarning']:
             msg = "%sWarning%s: " % (colors.RED, colors.NORMAL)
             msg += "This may be not enough for your output, leading to problems. Consider cleaning up"
             self.logger.warning(msg)


### PR DESCRIPTION
Together with CRABServer PR https://github.com/dmwm/CRABServer/pull/7987

Use isEnoughRucioQuota from CRABServer's `ServerUtilities.py`, minimum CRABServer version is [v3.231103](https://github.com/dmwm/CRABServer/releases/tag/v3.231103).

~~Note for one big change; I have moved initialize Rucio client to SubCommand class method because we need to get proper Rucio account to get account usage. You can only allow to get usage from your own account unless you have admin privilege. The problem occur when we want to use group area where it has different account.~~

~~In example, users want store outputs to Rucio group area which need different Rucio account (In our case, we need `crab_test_group` account, not `belforte` or `dmapelli` account). To get the account, we parse the LFN by using `getRucioAccountFromLFN()` from ServerUtilities.py.~~

~~But, LFN information for some command (e.g., `status`) are available inside `__call__` method. [Here an example](https://github.com/novicecpp/CRABClient/blob/38517e8e10f884c9f732736dca3aa6e3c88efbe7/src/python/CRABClient/Commands/status.py#L68).~~

EDITED:

In the end (after reviewew), I have decided to stick with `self.cmdconf['requiresRucio']=True` feature because, in theory, you can get quota from any user, but there is an permission issue in Rucio server so workaround code has been put in place (see comment in https://github.com/dmwm/CRABClient/pull/5247#issuecomment-1825785879).
