### PR TITLE
crab recover - new command

### DIFF
--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -79,6 +79,7 @@ parametersMapping = {
                                      {'default': False,      'config': ['JobType.disableAutomaticOutputCollection'],'type': 'BooleanType', 'required': False},
                                      {'default': None,       'config': ['JobType.copyCatTaskname'],         'type': 'StringType',  'required': False},
                                      {'default': 'prod',     'config': ['JobType.copyCatInstance'],         'type': 'StringType',  'required': False},
+                                     {'default': None,       'config': ['JobType.copyCatWorkdir'],          'type': 'StringType',  'required': False},
                                      {'default': [],         'config': ['JobType.inputFiles'],              'type': 'ListType',    'required': False}
                            ]
 }
@@ -152,6 +153,8 @@ commandsConfiguration = {
     'tasks'         : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': False, 'useCache': False, 'requiresProxyVOOptions': False, 'requiresLocalCache': False},
     'uploadlog'     : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': True,  'useCache': True,  'requiresProxyVOOptions': False, 'requiresLocalCache': False},
     'preparelocal'  : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': True,  'useCache': True,  'requiresProxyVOOptions': False, 'requiresLocalCache': True},
+    'recover'       : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': False, 'useCache': False, 'requiresProxyVOOptions': False, 'requiresLocalCache': False},
+    'getsandbox'    : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False,  'requiresDirOption': True,  'useCache': True,  'requiresProxyVOOptions': False, 'requiresLocalCache': True },
 }
 
 

--- a/src/python/CRABClient/ClientMapping.py
+++ b/src/python/CRABClient/ClientMapping.py
@@ -153,7 +153,7 @@ commandsConfiguration = {
     'tasks'         : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': False, 'useCache': False, 'requiresProxyVOOptions': False, 'requiresLocalCache': False},
     'uploadlog'     : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': True,  'useCache': True,  'requiresProxyVOOptions': False, 'requiresLocalCache': False},
     'preparelocal'  : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': True,  'useCache': True,  'requiresProxyVOOptions': False, 'requiresLocalCache': True},
-    'recover'       : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': False, 'useCache': False, 'requiresProxyVOOptions': False, 'requiresLocalCache': False},
+    'recover'       : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False, 'requiresDirOption': True, 'useCache': False, 'requiresProxyVOOptions': False, 'requiresLocalCache': False},
     'getsandbox'    : {'acceptsArguments': False, 'requiresREST': True,  'requiresRucio': False,  'requiresDirOption': True,  'useCache': True,  'requiresProxyVOOptions': False, 'requiresLocalCache': True },
 }
 

--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -356,7 +356,7 @@ def getRequestName(requestName=None):
     prefix = 'crab_'
     postfix = str(datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
 
-    if requestName is None or not isinstance(requestName, str) or len(requestName) == 0:
+    if requestName is None or requestName == "None" or not isinstance(requestName, str) or len(requestName) == 0:
         return prefix + postfix
     elif '/' in requestName:
         msg = "%sError%s: The '/' character is not accepted in the requestName parameter." % (colors.RED, colors.NORMAL)

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -270,6 +270,7 @@ class SubCommand(ConfigCommand):
 
         # Parse the command options/arguments.
         cmdargs = cmdargs or []
+        self.cmdargs = cmdargs
         (self.options, self.args) = self.parser.parse_args(cmdargs)
 
         self.transferringIds = None

--- a/src/python/CRABClient/Commands/getsandbox.py
+++ b/src/python/CRABClient/Commands/getsandbox.py
@@ -1,0 +1,95 @@
+import os
+
+from CRABClient.Commands.SubCommand import SubCommand
+
+from CRABClient.UserUtilities import curlGetFileFromURL, getColumn
+
+from ServerUtilities import downloadFromS3, getProxiedWebDir
+
+
+class getsandbox(SubCommand):
+    """
+    given a projdir, downloads locally the user sandbox.
+    It will try s3 first, otherwise it will fall back to the schedd WEBDIR.
+    """
+
+    name = "getsandbox"
+
+    def __call__(self):
+
+        # init. debug. print useful info
+        self.logger.debug("requestarea: %s", self.requestarea)
+        self.logger.debug("cachedinfo: %s", self.cachedinfo)
+
+        # get information necessary for next steps
+        # Get all of the columns from the database for a certain task
+        self.taskname = self.cachedinfo['RequestName']
+        self.crabDBInfo, _, _ = self.crabserver.get(api='task', data={'subresource':'search', 'workflow':self.taskname})
+        self.logger.debug("Got information from server oracle database: %s", self.crabDBInfo)
+
+        # arguments used by following functions
+        self.downloadDir = os.path.join(self.requestarea, "taskconfig")
+    
+        # download files: user sandbox, debug sandbox
+        filelist = []
+        # usersandbox = self.downloadUserSandbox()
+        usersandbox = self.downloadSandbox(
+            remotefile=getColumn(self.crabDBInfo, 'tm_user_sandbox'),
+            localfile='sandbox.tar.gz')
+        filelist.append(usersandbox)
+        # debugfiles = self.downloadDebug()
+        debugfiles = self.downloadSandbox(
+            remotefile=getColumn(self.crabDBInfo, 'tm_debug_files'),
+            localfile='debug_files.tar.gz')
+        filelist.append(debugfiles)
+
+        returnDict = {"commandStatus": "FAILED"}
+        if filelist:
+            returnDict = {"commandStatus": "SUCCESS", "sandbox_paths": filelist }
+
+        return returnDict
+
+    def downloadSandbox(self, remotefile, localfile):
+        """
+        Copy remotefile from s3 to localfile on local disk.
+
+        If remotefile is not s3, then as a fallback we look for the corresponding
+        localfile in the schedd webdir.
+        """
+        username = getColumn(self.crabDBInfo, 'tm_username')
+        sandboxFilename = remotefile
+
+        self.logger.debug("will download sandbox from s3: %s",sandboxFilename)
+
+        if not os.path.isdir(self.downloadDir):
+            os.mkdir(self.downloadDir)
+        localSandboxPath = os.path.join(self.downloadDir, localfile)
+
+        try:
+            downloadFromS3(crabserver=self.crabserver,
+                        filepath=localSandboxPath,
+                        objecttype='sandbox', logger=self.logger,
+                        tarballname=sandboxFilename,
+                        username=username
+                        )
+        except Exception as e:
+            self.logger.info("Sandbox download failed with %s", e)
+            self.logger.info("We will look for the sandbox on the webdir of the schedd")
+
+            webdir = getProxiedWebDir(crabserver=self.crabserver, task=self.taskname,
+                                    logFunction=self.logger.debug)
+            if not webdir:
+                webdir = getColumn(self.crabDBInfo, 'tm_user_webdir')
+            self.logger.debug("Downloading %s from %s", localfile, webdir)
+            httpCode = curlGetFileFromURL(webdir + '/' + localfile,
+                                        localSandboxPath, self.proxyfilename,
+                                        logger=self.logger)
+            if httpCode != 200:
+                self.logger.error("Failed to download %s from %s", localfile, webdir)
+                raise Exception("We could not locate the sandbox in the webdir neither.")
+                # we should use
+                # raise Exception("We could not locate the sandbox in the webdir neither.") from e
+                # but that is not py2 compatible...
+
+        return localSandboxPath
+

--- a/src/python/CRABClient/Commands/remake.py
+++ b/src/python/CRABClient/Commands/remake.py
@@ -35,7 +35,7 @@ class remake(SubCommand):
         requestarea = taskname.split(":", 1)[1].split("_", 1)[1]
         cachepath = os.path.join(requestarea, '.requestcache')
         if os.path.exists(cachepath):
-            self.logger.info("%sError%s: %s not created, because it already exists." % (colors.RED, colors.NORMAL, cachepath))
+            self.logger.info("%sWarning%s: %s not created, because it already exists." % (colors.RED, colors.NORMAL, cachepath))
         elif not os.path.exists(requestarea):
             self.logger.info('Remaking %s folder.' % (requestarea))
             try:

--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -292,7 +292,7 @@ class report(SubCommand):
         self.logger.debug("Result: %s" % dictresult)
         self.logger.info("Running crab status first to fetch necessary information.")
         # Get job statuses
-        statusDict = getMutedStatusInfo(self.logger)
+        statusDict = getMutedStatusInfo(logger=self.logger, proxy=self.proxyfilename)
 
         if not statusDict['jobList']:
             # No point in continuing if the job list is empty.
@@ -362,6 +362,7 @@ class report(SubCommand):
                             fd.close()
                 tarball.close()
             else:
+                # FIXME, dario, is this error message a copy-paste error?
                 self.logger.error("Failed to retrieve input dataset duplicate lumis.")
 
         return res

--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -362,8 +362,7 @@ class report(SubCommand):
                             fd.close()
                 tarball.close()
             else:
-                # FIXME, dario, is this error message a copy-paste error?
-                self.logger.error("Failed to retrieve input dataset duplicate lumis.")
+                self.logger.error("Failed to retrieve run_and_lumis.tar.gz")
 
         return res
 

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -119,11 +119,10 @@ class submit(SubCommand):
                       % (colors.RED, colors.NORMAL, non_edm_files)
                 self.logger.warning(msg)
 
-        self.logger.info("DM DEBUG - self.configuration {}".format(str(self.configuration)))
-        self.logger.info("DM DEBUG - self.configreq {}".format(self.configreq))
-        self.logger.info("DM DEBUG - jobconfig {}".format(jobconfig))
+        self.logger.debug("submit() - self.configuration {}".format(str(self.configuration)))
+        self.logger.debug("submit() - self.configreq {}".format(self.configreq))
+        self.logger.debug("submit() - jobconfig {}".format(jobconfig))
         self.configreq.update(jobconfig)
-        # import pdb; pdb.set_trace()
 
         server = self.crabserver
 

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -119,7 +119,12 @@ class submit(SubCommand):
                       % (colors.RED, colors.NORMAL, non_edm_files)
                 self.logger.warning(msg)
 
+        self.logger.info("DM DEBUG - self.configuration {}".format(str(self.configuration)))
+        self.logger.info("DM DEBUG - self.configreq {}".format(self.configreq))
+        self.logger.info("DM DEBUG - jobconfig {}".format(jobconfig))
         self.configreq.update(jobconfig)
+        # import pdb; pdb.set_trace()
+
         server = self.crabserver
 
         self.logger.info("Sending the request to the server at %s" % self.serverurl)
@@ -245,10 +250,11 @@ class submit(SubCommand):
         ## Load the external plugin or check that the crab plugin is valid.
         external_plugin_name = getattr(self.configuration.JobType, 'externalPluginFile', None)
         crab_plugin_name = getattr(self.configuration.JobType, 'pluginName', None)
-        crab_job_types = {'ANALYSIS': None, 'PRIVATEMC': None, 'COPYCAT': None} #getJobTypes()
+        crab_job_types = {'ANALYSIS': None, 'PRIVATEMC': None, 'COPYCAT': None, 'RECOVER': None} #getJobTypes()
         if external_plugin_name:
             addPlugin(external_plugin_name) # Do we need to do this here?
         if crab_plugin_name:
+            # FIXME we do not have only analysis or MC
             if crab_plugin_name.upper() not in crab_job_types:
                 msg = "Invalid CRAB configuration: Parameter JobType.pluginName has an invalid value ('%s')." % (crab_plugin_name)
                 msg += "\nAllowed values are: %s." % (", ".join(['%s' % job_type for job_type in crab_job_types.keys()]))

--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -253,13 +253,19 @@ class submit(SubCommand):
         if external_plugin_name:
             addPlugin(external_plugin_name) # Do we need to do this here?
         if crab_plugin_name:
-            # FIXME we do not have only analysis or MC
             if crab_plugin_name.upper() not in crab_job_types:
                 msg = "Invalid CRAB configuration: Parameter JobType.pluginName has an invalid value ('%s')." % (crab_plugin_name)
                 msg += "\nAllowed values are: %s." % (", ".join(['%s' % job_type for job_type in crab_job_types.keys()]))
                 return False, msg
-            msg = "Will use CRAB %s plugin" % ("Analysis" if crab_plugin_name.upper() == 'ANALYSIS' else "PrivateMC")
-            msg += " (i.e. will run %s job type)." % ("an analysis" if crab_plugin_name.upper() == 'ANALYSIS' else "a MC generation")
+            msg = "Will use CRAB plugin %s" % (crab_plugin_name.upper())
+            if crab_plugin_name.upper() == 'ANALYSIS':
+                msg += " (i.e. will run an analysis job type)."
+            elif crab_plugin_name.upper() == 'PRIVATEMC':
+                msg += " (i.e. will run an a MC generation job type)."
+            elif crab_plugin_name.upper() == 'COPYCAT':
+                msg += " (i.e. will run a copy of a task. the exact job type will be defined later)."
+            elif crab_plugin_name.upper() == 'RECOVER':
+                msg += " (i.e. will run the recovery of a task. the exact job type will be defined later)."
             self.logger.debug(msg)
 
         ## Check that the requested memory does not exceed the allowed maximum.

--- a/src/python/CRABClient/JobType/Recover.py
+++ b/src/python/CRABClient/JobType/Recover.py
@@ -150,6 +150,7 @@ class Recover(BasicJobType):
 
         copyOfTaskCrabConfig = os.path.join(self.config.JobType.copyCatWorkdir, "debug_sandbox", 'debug', 'crabConfig.py')
         copyOfTaskPSet =       os.path.join(self.config.JobType.copyCatWorkdir, "debug_sandbox", 'debug', 'originalPSet.py')
+        self.config.JobType.psetName = copyOfTaskPSet
         debugFilesUploadResult = None
         with UserTarball(name=newDebugPath, logger=self.logger, config=self.config,
                          crabserver=self.crabserver, s3tester=self.s3tester) as dtb:
@@ -162,16 +163,6 @@ class Recover(BasicJobType):
                        "More details can be found in %s" % (e, self.logger.logfile))
                 LOGGERS['CRAB3'].exception(msg) #the traceback is only printed into the logfile
 
-        # parse config (copy from submit subcommand)
-        ## TODO FIXME DM dario - maybe i can avoid loading it again, i already pass it...
-        cfgcmd = ConfigCommand()
-        cfgcmd.logger = self.logger
-        cfgcmd.loadConfig(copyOfTaskCrabConfig)
-        #cfgcmd.loadConfig('crabConfig2.py')
-        cfgcmd.configuration.JobType.psetName = copyOfTaskPSet
-        # remove lumimasks here to prevent loading lumis form file
-        # cfgcmd.configuration.Data.lumiMask = None
-        # cfgcmd.configuration.Data.runRange = None
 
         configreq = {'dryrun': 0}
         for param in parametersMapping['on-server']:
@@ -179,7 +170,7 @@ class Recover(BasicJobType):
             config_params = parametersMapping['on-server'][param]['config']
             for config_param in config_params:
                 attrs = config_param.split('.')
-                temp = cfgcmd.configuration
+                temp = self.config
                 for attr in attrs:
                     temp = getattr(temp, attr, None)
                     if temp is None:

--- a/src/python/CRABClient/JobType/Recover.py
+++ b/src/python/CRABClient/JobType/Recover.py
@@ -1,0 +1,304 @@
+# this is an experimantal new feature introduced by Marco and never fully tested/used
+# will worry about pylint if and when we decide to use it and look at details
+#pylint: skip-file
+"""
+CopyCat job type plug-in
+"""
+
+import os
+import re
+import math
+import shutil
+import string
+import tempfile
+from functools import reduce
+from ast import literal_eval
+import json
+import hashlib
+import tarfile
+import ast
+import json
+
+try:
+    from FWCore.PythonUtilities.LumiList import LumiList
+except Exception:  # pylint: disable=broad-except
+    # if FWCore version is not py3 compatible, use our own
+    from CRABClient.LumiList import LumiList
+
+from ServerUtilities import BOOTSTRAP_CFGFILE_DUMP, getProxiedWebDir, NEW_USER_SANDBOX_EXCLUSIONS
+from ServerUtilities import SERVICE_INSTANCES
+
+import CRABClient.Emulator
+from CRABClient import __version__
+from CRABClient.UserUtilities import curlGetFileFromURL
+from CRABClient.ClientUtilities import colors, LOGGERS, getColumn, getJobTypes, DBSURLS
+from CRABClient.JobType.UserTarball import UserTarball
+from CRABClient.JobType.CMSSWConfig import CMSSWConfig
+# from CRABClient.JobType._AnalysisNoUpload import _AnalysisNoUpload
+from CRABClient.JobType.BasicJobType import BasicJobType
+from CRABClient.ClientMapping import getParamDefaultValue
+from CRABClient.JobType.LumiMask import getLumiList, getRunList
+from CRABClient.ClientUtilities import bootstrapDone, BOOTSTRAP_CFGFILE, BOOTSTRAP_CFGFILE_PKL
+from CRABClient.ClientExceptions import ClientException, EnvironmentException, ConfigurationException, CachefileNotFoundException
+from CRABClient.Commands.SubCommand import ConfigCommand
+from CRABClient.ClientMapping import parametersMapping, getParamDefaultValue
+from ServerUtilities import uploadToS3, downloadFromS3
+
+
+class Recover(BasicJobType):
+    """
+    CMSSW job type plug-in
+
+    Access the configuration of the task that we are submitting with self.config
+    """
+
+    def initCRABRest(self):
+        """
+        - self.crabserver is the destination, where to submit recovery task. already created for us.
+        - self.crabserverCopyOfTask is the source, where the failing task was submitted to
+        """
+        serverFactory = CRABClient.Emulator.getEmulator('rest')
+        serverhost = SERVICE_INSTANCES.get(self.config.JobType.copyCatInstance)
+        self.crabserverCopyOfTask = serverFactory(hostname=serverhost['restHost'], localcert=self.proxyfilename,
+                               localkey=self.proxyfilename, retry=2, logger=self.logger,
+                               verbose=False, userAgent='CRABClient')
+        self.crabserverCopyOfTask.setDbInstance(serverhost['dbInstance'])
+
+        # after having an instance of the server where the original task was submitted, 
+        # we can now set the General.instance to be the destination server
+        self.config.General.instance = self.config.JobType.copyCatInstance
+
+    def getTaskDict(self):
+        #getting information about the task
+        inputlist = {'subresource':'search', 'workflow': self.config.JobType.copyCatTaskname}
+
+        dictret, _, _ = self.crabserverCopyOfTask.get(api='task', data=inputlist)
+
+        task = {}
+        self.logger.debug(dictret)
+        task['username'] = getColumn(dictret, 'tm_username')
+        task['jobarch'] = getColumn(dictret, 'tm_job_arch')
+        task['jobsw'] = getColumn(dictret, 'tm_job_sw')
+        task['inputdata'] = getColumn(dictret, 'tm_input_dataset')
+        # crabclient send none to server and server confuse
+        if not task['inputdata']:
+            task.pop('inputdata')
+
+        # it is a list in string format
+        task['edmoutfiles'] = ast.literal_eval(getColumn(dictret, 'tm_edm_outfiles'))
+        task['tfileoutfiles'] = ast.literal_eval(getColumn(dictret, 'tm_tfile_outfiles'))
+        task['addoutputfiles'] = ast.literal_eval(getColumn(dictret, 'tm_outfiles'))
+        task['userfiles'] = ast.literal_eval(getColumn(dictret, 'tm_user_files'))
+
+        # use for download original task cache
+        task['cachefilename'] = getColumn(dictret, 'tm_user_sandbox')
+        task['debugfilename'] = getColumn(dictret, 'tm_debug_files')
+
+        task['primarydataset'] = getColumn(dictret, 'tm_primary_dataset')
+        task['jobtype'] = getColumn(dictret, 'tm_job_type')
+        tmp = ast.literal_eval(getColumn(dictret, 'tm_split_args'))
+        task['runs'] = tmp['runs']
+        task['lumis'] = tmp['lumis']
+        #import pdb; pdb.set_trace()
+        tmp = json.loads(getColumn(dictret, 'tm_user_config'))
+        if tmp['inputblocks']:
+            task['inputblocks'] = tmp['inputblocks']
+
+        if task['jobtype'] == 'PrivateMC':
+            task['generator'] = getColumn(dictret, 'tm_generator')
+
+        # if the original task has publication enabled, then the recovery task
+        # publishes in the same DBS dataset
+        failingTaskPublishName = getColumn(dictret, 'tm_publish_name')
+        # remove -0...0 from publish name, see https://github.com/dmwm/CRABServer/issues/4947
+        failingTaskPublishName = failingTaskPublishName.replace("-00000000000000000000000000000000", "")
+        task['publishname2'] = failingTaskPublishName
+        # task['jobtype'] = getColumn(dictret, 'tm_publish_groupname')
+
+        # this needs to be passed in recover.py, needs the full path
+        # task["scriptexe"] = getColumn(self.failingCrabDBInfo, 'tm_scriptexe')
+
+        return task
+
+    def run(self, filecacheurl = None):
+        """
+        Override run() for JobType Recover.
+
+        - 'addoutputfiles': [] -> removed
+        - 'tfileoutfiles': [] -> removed, ignoring for the time being
+        - 'edmoutfiles': ['output.root'], 
+        
+        'jobarch': 'el8_amd64_gcc11', 'jobsw': 'CMSSW_13_0_3', 
+        'inputdata': '/GenericTTbar/HC-CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/AODSIM', 
+        'cacheurl': 'https://cmsweb-test2.cern.ch/S3/crabcache_dev', 
+        'cachefilename': 'f1fed93419f0d25d8d7dd1b7331cff56f50376ebfe0c6c77daf9bfd6da6daade.tar.gz', 
+        'debugfilename': 'e435f28faecdb441796d2696b9b6f955108a0217ad602bca6114638272ab9a82.tar.gz',
+        'jobtype': 'Analysis'}
+        """
+
+        self.initCRABRest()
+        jobInfoDict = self.getTaskDict()
+
+        # reupload sandbox with new hash (from sandbox filename)
+        newCachefilename = "{}.tar.gz".format(hashlib.sha256(jobInfoDict['cachefilename'].encode('utf-8')).hexdigest())
+        localPathCachefilename = os.path.join(self.config.JobType.copyCatWorkdir, "taskconfig", 'sandbox.tar.gz')
+        uploadToS3(crabserver=self.crabserver, objecttype='sandbox', filepath=localPathCachefilename,
+                   tarballname=newCachefilename, logger=self.logger)
+
+        newDebugfilename = "{}.tar.gz".format(hashlib.sha256(jobInfoDict['debugfilename'].encode('utf-8')).hexdigest())
+        newDebugPath = os.path.join(self.workdir, newDebugfilename)
+
+        copyOfTaskCrabConfig = os.path.join(self.config.JobType.copyCatWorkdir, "debug_sandbox", 'debug', 'crabConfig.py')
+        copyOfTaskPSet =       os.path.join(self.config.JobType.copyCatWorkdir, "debug_sandbox", 'debug', 'originalPSet.py')
+        debugFilesUploadResult = None
+        with UserTarball(name=newDebugPath, logger=self.logger, config=self.config,
+                         crabserver=self.crabserver, s3tester=self.s3tester) as dtb:
+
+            dtb.addMonFiles()
+            try:
+                debugFilesUploadResult = dtb.upload(filecacheurl = filecacheurl)
+            except Exception as e:
+                msg = ("Problem uploading debug_files.tar.gz.\nError message: %s.\n"
+                       "More details can be found in %s" % (e, self.logger.logfile))
+                LOGGERS['CRAB3'].exception(msg) #the traceback is only printed into the logfile
+
+        # parse config (copy from submit subcommand)
+        ## TODO FIXME DM dario - maybe i can avoid loading it again, i already pass it...
+        cfgcmd = ConfigCommand()
+        cfgcmd.logger = self.logger
+        cfgcmd.loadConfig(copyOfTaskCrabConfig)
+        #cfgcmd.loadConfig('crabConfig2.py')
+        cfgcmd.configuration.JobType.psetName = copyOfTaskPSet
+        # remove lumimasks here to prevent loading lumis form file
+        # cfgcmd.configuration.Data.lumiMask = None
+        # cfgcmd.configuration.Data.runRange = None
+
+        configreq = {'dryrun': 0}
+        for param in parametersMapping['on-server']:
+            default = parametersMapping['on-server'][param]['default']
+            config_params = parametersMapping['on-server'][param]['config']
+            for config_param in config_params:
+                attrs = config_param.split('.')
+                temp = cfgcmd.configuration
+                for attr in attrs:
+                    temp = getattr(temp, attr, None)
+                    if temp is None:
+                        break
+                if temp is not None:
+                    configreq[param] = temp
+                    break
+                elif default is not None:
+                    configreq[param] = default
+                    temp = default
+                else:
+                    ## Parameter not strictly required.
+                    pass
+            ## Translate boolean flags into integers.
+            if param in ['savelogsflag', 'publication', 'nonprodsw', 'useparent',\
+                           'ignorelocality', 'saveoutput', 'oneEventMode', 'nonvaliddata', 'ignoreglobalblacklist',\
+                           'partialdataset', 'requireaccelerator']:
+                configreq[param] = 1 if temp else 0
+            ## Translate DBS URL aliases into DBS URLs.
+            elif param in ['dbsurl', 'publishdbsurl']:
+                if param == 'dbsurl':
+                    dbstype = 'reader'
+                elif param == 'publishdbsurl':
+                    dbstype = 'writer'
+                allowed_dbsurls = DBSURLS[dbstype].values()
+                allowed_dbsurls_aliases = DBSURLS[dbstype].keys()
+                if configreq[param] in allowed_dbsurls_aliases:
+                    configreq[param] = DBSURLS[dbstype][configreq[param]]
+                elif configreq[param].rstrip('/') in allowed_dbsurls:
+                    configreq[param] = configreq[param].rstrip('/')
+            elif param == 'scriptexe' and 'scriptexe' in configreq:
+                configreq[param] = os.path.basename(configreq[param])
+            elif param in ['acceleratorparams'] and param in configreq:
+                configreq[param] = json.dumps(configreq[param])
+
+        configreq.update(jobInfoDict)
+
+        ## RECOVER - set lumimask from crab report, not from original task - START
+        ## copied from Analysis.py
+        lumi_mask_name = getattr(self.config.Data, 'lumiMask', None)
+        lumi_list = None
+        if lumi_mask_name:
+            self.logger.debug("Attaching lumi mask %s to the request" % (lumi_mask_name))
+            try:
+                lumi_list = getLumiList(lumi_mask_name, logger = self.logger)
+            except ValueError as ex:
+                msg  = "%sError%s:" % (colors.RED, colors.NORMAL)
+                msg += " Failed to load lumi mask %s : %s" % (lumi_mask_name, ex)
+                raise ConfigurationException(msg)
+        run_ranges = getattr(self.config.Data, 'runRange', None)
+        if run_ranges:
+            run_ranges_is_valid = re.match('^\d+((?!(-\d+-))(\,|\-)\d+)*$', run_ranges)
+            if run_ranges_is_valid:
+                run_list = getRunList(run_ranges)
+                if lumi_list:
+                    lumi_list.selectRuns(run_list)
+                    if not lumi_list:
+                        msg = "Invalid CRAB configuration: The intersection between the lumi mask and the run range is null."
+                        raise ConfigurationException(msg)
+                else:
+                    if len(run_list) > 50000:
+                        msg  = "CRAB configuration parameter Data.runRange includes %s runs." % str(len(run_list))
+                        msg += " When Data.lumiMask is not specified, Data.runRange can not include more than 50000 runs."
+                        raise ConfigurationException(msg)
+                    lumi_list = LumiList(runs = run_list)
+            else:
+                msg = "Invalid CRAB configuration: Parameter Data.runRange should be a comma separated list of integers or (inclusive) ranges. Example: '12345,99900-99910'"
+                raise ConfigurationException(msg)
+        if lumi_list:
+            configreq['runs'] = lumi_list.getRuns()
+            ## For each run we encode the lumis as a string representing a list of integers: [[1,2],[5,5]] ==> '1,2,5,5'
+            lumi_mask = lumi_list.getCompactList()
+            configreq['lumis'] = [str(reduce(lambda x,y: x+y, lumi_mask[run]))[1:-1].replace(' ','') for run in configreq['runs']]
+        ## RECOVER - set lumimask from crab report, not from original task - END
+
+
+        # new filename
+        configreq['cachefilename'] = newCachefilename
+        configreq['debugfilename'] = newDebugfilename
+        configreq['debugfilename'] = "%s.tar.gz" % debugFilesUploadResult
+        configreq['cacheurl'] = filecacheurl
+
+        # pop
+        configreq.pop('username', None)
+        configreq.pop('workflow', None)
+        configreq.pop('vogroup', None)
+        # outputlfndirbase
+        configreq.pop('lfn', None)
+        configreq.pop('asyncdest', None)
+
+        # optional pop
+        if getattr(self.config.Data, 'splitting', None):
+            configreq.pop('splitalgo', None)
+        if getattr(self.config.Data, 'totalUnits', None):
+            configreq.pop('totalunits', None)
+        if getattr(self.config.Data, 'unitsPerJob', None):
+            configreq.pop('algoargs', None)
+        if getattr(self.config.JobType, 'maxJobRuntimeMin', None):
+            configreq.pop('maxjobruntime', None)
+        if getattr(self.config.Data, 'publication', None) != None:
+            configreq.pop('publication', None)
+        if getattr(self.config.General, 'transferLogs', None) != None:
+            configreq.pop('savelogsflag', None)
+
+        return '', configreq
+
+
+    def validateConfig(self, config):
+        """
+        """
+        # skip it all for now
+        valid, reason = self.validateBasicConfig(config)
+        if not valid:
+            return valid, reason
+
+        return True, "Valid configuration"
+
+    def validateBasicConfig(self, config):
+        """
+
+        """
+        return True, "Valid configuration"

--- a/src/python/CRABClient/UserUtilities.py
+++ b/src/python/CRABClient/UserUtilities.py
@@ -193,12 +193,16 @@ def setConsoleLogLevel(lvl):
         for h in logging.getLogger('CRAB3.all').handlers:
             h.setLevel(lvl)
 
-def getMutedStatusInfo(logger):
+def getMutedStatusInfo(logger=None, proxy=None):
     """
     Mute the status console output before calling status and change it back to normal afterwards.
     """
     mod = __import__('CRABClient.Commands.status', fromlist='status')
-    cmdobj = getattr(mod, 'status')(logger)
+    cmdargs = []
+    if proxy:
+        cmdargs.append("--proxy")
+        cmdargs.append(proxy)
+    cmdobj = getattr(mod, 'status')(logger=logger, cmdargs=cmdargs)
     loglevel = getConsoleLogLevel()
     setConsoleLogLevel(LOGLEVEL_MUTE)
     statusDict = cmdobj.__call__()


### PR DESCRIPTION
### scope

First implementation of automatic submission of a recovery task, without the need for users to follow instructions at [1]

how to trigger this new functionality: from crab client, run `crab recover --task=<taskname>`.

This command **supports** the recovery task for a task that

- has jobtype analysis
- uses a splitting algorithm that is aware of lumisections (automatic, lumibased, eventawarelumibased)

This command supports, but we have **not thoroughly** tested

- recover of a task submitted with automatic splitting [**]. User are encouraged to use it, but some extra caution may be needed.

does **not** support recovery of a task

- filebased splitting: will be done at a later stage
- privatemc: makes little sense, a user can just submit a new task.

### status

- [x] needs a reivew
- [x] ~~need to suppress debug logs, which may be useful for the review~~

changes  since out chat on 2023-11-10 afternoon:

- (functional) I changed the default strategy to "notPublished"
- (functional) killed is a final state. cooloff is a transient state, held is a transient state
- (functional) improve error message when crab report outputs are empty [5]
- (functional) improved stdout log messages
- (technical) crab remake does not need to be changed. It was a merge error on my side.
    - I needed to account for this `if` not having a return [4] 
- (technical) suppress debug messages
- (technical) use exceptions, not asserts, suggested by @novicecpp 
- (technical) jobtype Recover.py load task configuration only once, not twice as copycat.py needs to do.

### details

Entrypoint: the new file `src/python/CRABClient/Commands/recover.py`. 

Since I needed to convert a manual list of actions into a crab client command, I opted for a procedural approach. I grouped the manual actions in steps, I created a function `step*` for very step. Some steps have side effects.

apart from technicalities, we should focus our attention to

- how do we decide that the original task is actually in a final state and not in a transient state? I am not sure that the current policy can identify a static automatic splitting task.

technical details that may be not trivial to grasp

- i take the task config, pset and script exe from the original sandboxes
- I override task config options via crab submit command line options, see [2]
- I use the "Recover" jobtype, which means that the command "submit.py" will call at [3]  the new file `src/python/CRABClient/JobType/Recover.py`
- `src/python/CRABClient/JobType/Recover.py` is a modification of `src/python/CRABClient/JobType/CopyOfTask.py`, which is the original copycat implementation by @novicecpp 
    - Since I do not want to get credits for something I did not do, I can remove that file from this PR before merging. It is here just because it will be easier to compare the two when reviewing
- differences between mine and Wa's implementation
    - Wa's copyoftask assumes that the task that needs to be copied is specified in the task config
    - while in this PR we want to specify the original task name in the command line. 
    - Wa did not need to change the lumimask
    - Wa did not need to care about publishing the output in the same DBS dataset as the original task

---

[**]

when we recover a task that has been submitted with automatic splitting we can have

- some jobs are still in a transient state. crab recover will kill the task, but will not submit the recovery task. The user will need to run crab recover again
- all jobs finished and some failed. crab recover will kill the task (disabling resubmission in the future), will check all job user status, will proceed with crab submit
- all the jobs that have been submitted already are in a final state, but not all jobs have been submitted yet. crab recover will kill the task, will check that all jobs in the schedd are in a final state, then will proceed with crab submit
    - danger: since crab recover does not wait, there is a small possibility that some new jobs are submitted between the execution of crab kill and crab report.
    - however, TW should kill all those jobs soon enough not to have them create any new output file. I am confident that this will not cause any problem

[1] https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3FAQ#Recovery_task
[2] https://twiki.cern.ch/twiki/bin/view/CMSPublic/CRAB3ConfigurationFile#Passing_CRAB_configuration_param
[3] https://github.com/dmwm/CRABClient/blob/0edda22ce9af3ff76a41bc25fecb269762f54a6f/src/python/CRABClient/Commands/submit.py#L107

[4] https://github.com/dmwm/CRABClient/blob/a18cbd0856b48ad4d2db728e613efd9ac9edc0f4/src/python/CRABClient/Commands/remake.py#L23

[5] 

- `231110_180452:dmapelli_crab_test_20231110_190450` : original failing task. 3/5 jobs published
- recovered by `231110_185245:dmapelli_crab_20231110_195244` (crab report created `notPublished.json`). 2/2 jobs published
- recovered again by `231110_190318:dmapelli_crab_20231110_200317`. bug, should not have been submitted. 1/2 jobs published
- recovered again by `231110_194043:dmapelli_crab_20231110_204042`. bug, should not have been submitted. 2/2 jobs published
- bug fixed, but now crab recover fails with a cryptic message that I am not really sure how to improve. I will need to sleep on this.

<details><summary>231110_180452:dmapelli_crab_test_20231110_190450 , on prod</summary>

```plaintext
> crab recover --task=231110_180452:dmapelli_crab_test_20231110_190450 --proxy=$X509_USER_PROXY
[...]
DM DEBUG - report, retval: {'numFilesProcessed': 1, 'numEventsRead': 1800, 'numEventsWritten': {'EDM': 1800, 'TFile': 0, 'FAKE': 0}, 'inputDatasetLumis': {'1': [[1, 49], [51, 67], [69, 129], [131, 235], [237, 238], [240, 255], [257, 301], [303, 415], [417, 516], [518, 526], [528, 555], [557, 1173], [1175, 1209], [1211, 1252], [1254, 1436], [1438, 1451], [1453, 1583], [1585, 1605], [1607, 1947], [1949, 1992], [1994, 2603], [2605, 3142], [3144, 3334]]}, 'inputDatasetDuplicateLumis': {}, 'lumisToProcess': {'1': [[419, 419], [592, 592], [652, 652], [1261, 1261], [1849, 1849], [1858, 1858], [2083, 2083], [2465, 2465], [2702, 2702], [2748, 2748]]}, 'processedLumis': {'1': [[419, 419], [592, 592], [652, 652], [1261, 1261], [2702, 2702], [2748, 2748]]}, 'outputDatasetsLumis': {'/GenericTTbar/dmapelli-crab_test_20231110_190450-bb695911428445ed11a1006c9940df69/USER': {'1': [[419, 419], [592, 592], [652, 652], [1261, 1261], [1849, 1849], [1858, 1858], [2083, 2083], [2465, 2465], [2702, 2702], [2748, 2748]]}}, 'outputDatasetsNumEvents': {'/GenericTTbar/dmapelli-crab_test_20231110_190450-bb695911428445ed11a1006c9940df69/USER': 3000}, 'outputFilesDuplicateLumis': {}, 'notProcessedLumis': {}, 'commandStatus': 'SUCCESS'}
DM DEBUG - report, after, self.configuration: None
DM DEBUG - recovery task will process lumis contained in file crab_test_20231110_190450/results/notPublishedLumis.json
Command recover failed
```

</details>