### PR TITLE
Add suffix uuid string to filename and subdir

### DIFF
--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import datetime
+import uuid
 
 from CRABClient.Commands.SubCommand import SubCommand
 from CRABClient.ClientUtilities import (execute_command, colors, cmd_exist,
@@ -86,8 +87,9 @@ class checkwrite(SubCommand):
 
         self.logger.info('Will check write permission in %s on site %s', self.lfnPrefix, self.options.sitename)
         timestamp = str(time.strftime("%Y%m%d_%H%M%S"))
-        self.filename = 'crab3checkwrite_' + timestamp  + '.tmp'
-        self.subdir = 'crab3checkwrite_' + timestamp
+        uuidStr = str(uuid.uuid4())
+        self.filename = uuidStr + '.tmp'
+        self.subdir = 'crab3checkwrite_' + timestamp + '_' + uuidStr
         lfn = self.lfnPrefix + '/' + self.subdir + '/' + self.filename
         try:
             if self.rucio:


### PR DESCRIPTION
Fix https://github.com/dmwm/CRABClient/issues/5296

Need to add suffix uuid to both `self.filename` and `self.subdir` because we also test deleting directory.

Tested manually on el7 CMSSW_10_6_40 and el8 CMSSW_13_0_2.
(Did not test on slc6 because there is no `checkwrite` in command list of CV)