### PR TITLE
completions - generate_completions script works in py3

### DIFF
--- a/etc/crab-bash-completion.sh
+++ b/etc/crab-bash-completion.sh
@@ -23,101 +23,41 @@ _UseCrab ()
         "")
             case "$cur" in
             "")
-                COMPREPLY=( $(compgen -W '--version --help -h --quiet --debug status tasks proceed checkwrite getlog checkusername checkdataset checkfile submit getoutput resubmit kill uploadlog remake report preparelocal createmyproxy setdatasetstatus setfilestatus' -- $cur) )
+                COMPREPLY=( $(compgen -W '--version --help -h --quiet --debug status tasks submit proceed checkdataset checkfile checkusername checkwrite createmyproxy getlog getoutput getsandbox kill preparelocal recover remake report resubmit setdatasetstatus setfilestatus uploadlog' -- $cur) )
                 ;;
             -*)
                 COMPREPLY=( $(compgen -W '--version --help -h --quiet --debug' -- $cur) )
                 ;;
             *)
-                COMPREPLY=( $(compgen -W 'status tasks proceed checkwrite getlog checkusername checkdataset checkfile submit getoutput resubmit kill uploadlog remake report preparelocal createmyproxy setdatasetstatus setfilestatus' -- $cur) )
+                COMPREPLY=( $(compgen -W 'status tasks submit proceed checkdataset checkfile checkusername checkwrite createmyproxy getlog getoutput getsandbox kill preparelocal recover remake report resubmit setdatasetstatus setfilestatus uploadlog' -- $cur) )
                 ;;
             esac
             ;;
 
-        "tasks")
+        "checkdataset")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --fromdate --days --status --proxy --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --dataset --dbs-instance --proxy' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "checkwrite")
+        "chkd")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --site --lfn --checksum --command --proxy --voRole --voGroup' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --dataset --dbs-instance --proxy' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "getlog")
+        "checkfile")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --short --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "kill")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --killwarning --proxy --dir -d --task --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "rmk")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --task --proxy --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "out")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "sub")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --wait --dryrun --skip-estimates --config -c --proxy --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "rep")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --outputdir --recovery --dbs --proxy --dir -d --task --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "chkw")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --site --lfn --checksum --command --proxy --voRole --voGroup' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --checksum --lfn --dbs-instance --rucio-scope --proxy' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
@@ -134,50 +74,40 @@ _UseCrab ()
             esac
             ;;
 
-        "submit")
+        "checkwrite")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --wait --dryrun --skip-estimates --config -c --proxy --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --site --lfn --checksum --command --proxy --voRole --voGroup' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "getoutput")
+        "chkw")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --site --lfn --checksum --command --proxy --voRole --voGroup' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "resubmit")
+        "createmyproxy")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --wait --force --publication --jobids --sitewhitelist --siteblacklist --maxjobruntime --maxmemory --numcores --priority --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --days --proxy --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "status")
+        "getlog")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --long --json --summary --verboseErrors --sort --jobids --proxy --dir -d --task --instance' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "uplog")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --logpath --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --short --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --voRole --voGroup --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
@@ -187,27 +117,67 @@ _UseCrab ()
         "log")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --short --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --short --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --voRole --voGroup --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "uploadlog")
+        "getoutput")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --logpath --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --voRole --voGroup --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "report")
+        "output")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --outputdir --recovery --dbs --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --voRole --voGroup --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "out")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --voRole --voGroup --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "getsandbox")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "kill")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --killwarning --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "preparelocal")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --enableStageout --jobid --destdir --proxy --dir -d --task --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
@@ -224,10 +194,20 @@ _UseCrab ()
             esac
             ;;
 
-        "st")
+        "recover")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --long --json --summary --verboseErrors --sort --jobids --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --forcekill --strategy --destinstance --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "rec")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --forcekill --strategy --destinstance --proxy --dir -d --task --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
@@ -244,50 +224,40 @@ _UseCrab ()
             esac
             ;;
 
-        "output")
+        "rmk")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --dump --xrootd --quantity --parallel --wait --outputpath --jobids --checksum --command --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --task --proxy --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "preparelocal")
+        "report")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --jobid --enableStageout --destdir --proxy --dir -d --task --instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --outputdir --recovery --dbs --proxy --dir -d --task --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "createmyproxy")
+        "rep")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --days' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --outputdir --recovery --dbs --proxy --dir -d --task --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
-        "checkdataset")
+        "resubmit")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --dataset' -- $cur) )
-                    ;;
-                *)
-                    COMPREPLY=( $(compgen -f $cur) )
-            esac
-            ;;
-
-        "checkfile")
-            case "$cur" in
-                -*)
-                    COMPREPLY=( $(compgen -W '--help -h --lfn --dbs-instance --rucio-scope --checksum' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --force --publication --jobids --sitewhitelist --siteblacklist --maxjobruntime --maxmemory --numcores --priority --proxy --dir -d --task --instance' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
@@ -297,7 +267,7 @@ _UseCrab ()
         "setdatasetstatus")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --status --dataset --dbs-instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --recursive --dbs-instance --dataset --status --proxy' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
@@ -307,20 +277,88 @@ _UseCrab ()
         "setfilestatus")
             case "$cur" in
                 -*)
-                    COMPREPLY=( $(compgen -W '--help -h --status --dataset --files --dbs-instance' -- $cur) )
+                    COMPREPLY=( $(compgen -W '--help -h --dbs-instance --dataset -d --status -s --files -f --proxy' -- $cur) )
                     ;;
                 *)
                     COMPREPLY=( $(compgen -f $cur) )
             esac
             ;;
 
+        "status")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --long --json --summary --verboseErrors --sort --jobids --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "st")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --long --json --summary --verboseErrors --sort --jobids --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "submit")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --wait --dryrun --skip-estimates --config -c --proxy --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "sub")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --wait --dryrun --skip-estimates --config -c --proxy --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "tasks")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --fromdate --days --status --proxy --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "uploadlog")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
+
+        "uplog")
+            case "$cur" in
+                -*)
+                    COMPREPLY=( $(compgen -W '--help -h --proxy --dir -d --task --instance' -- $cur) )
+                    ;;
+                *)
+                    COMPREPLY=( $(compgen -f $cur) )
+            esac
+            ;;
 
         *)
-            COMPREPLY=( $(compgen -W 'status tasks proceed checkwrite getlog checkusername checkdataset checkfile submit getoutput resubmit kill uploadlog remake report preparelocal setdatasetstatus setfilestatus' -- $cur) )
+            COMPREPLY=( $(compgen -W 'status tasks submit proceed checkdataset checkfile checkusername checkwrite createmyproxy getlog getoutput getsandbox kill preparelocal recover remake report resubmit setdatasetstatus setfilestatus uploadlog' -- $cur) )
             ;;
     esac
 
     return 0
 }
-complete -F _UseCrab -o filenames crab
-
+complete -F _UseCrab -o filenames -o nosort crab

--- a/scripts/generate_completion.py
+++ b/scripts/generate_completion.py
@@ -34,8 +34,6 @@ from CRABClient.ClientMapping import commandsConfiguration
 
 logging.basicConfig(level=logging.INFO)
 
-import argparse
-
 template = """
 _UseCrab ()
 {{
@@ -119,7 +117,6 @@ def main():
     spec.loader.exec_module(crab)
 
     client = crab.CRABClient()
-    logger = DummyLogger()
 
     longnames = []
     commands = {}
@@ -129,7 +126,7 @@ def main():
         options.append(opt.get_opt_string())
         options += opt._short_opts
 
-    for k, v in client.subCommands.items():
+    for _, v in client.subCommands.items():
         class DummyCmd(v):
             def __init__(self):
                 self.parser = CRABCmdOptParser(v.name, '', False)
@@ -177,7 +174,7 @@ def main():
     longnames = [l_w[0] for l_w in longnames_w]
     logging.info(longnames)
 
-    with open(p_args.output_file, "w") as f_:
+    with open(p_args.output_file, "w", encoding="utf-8") as f_:
         f_.write(template.format(
             topcommands=' '.join(longnames),
             topoptions=' '.join(options),

--- a/scripts/generate_completion.py
+++ b/scripts/generate_completion.py
@@ -1,9 +1,30 @@
-from __future__ import print_function
-import imp
-import optparse
+"""
+
+how to use:
+
+> cd CRABClient
+> python3 scripts/generate_completions.py -o etc/crab-bash-completion.sh
+
+Known limitations:
+
+- sorting of the suggestions can be broken despite the use of "-o nosort".
+  For example when using "set completion-ignore-case on" on bash 4.4.20, 
+  which is the version installed on lxplus8. 
+  see https://unix.stackexchange.com/a/567937
+
+"""
+
+import importlib.util
+import sys
+import argparse
+import logging
 
 from CRABClient.CRABOptParser import CRABCmdOptParser
 from CRABClient.ClientMapping import commandsConfiguration
+
+logging.basicConfig(level=logging.INFO)
+
+import argparse
 
 template = """
 _UseCrab ()
@@ -48,7 +69,7 @@ _UseCrab ()
 
     return 0
 }}
-complete -F _UseCrab -o filenames crab
+complete -F _UseCrab -o filenames -o nosort crab
 """
 
 template_cmd = """
@@ -70,51 +91,87 @@ class DummyLogger(object):
     def logfile(self):
         return ''
 
-crab = imp.load_source('crab', 'bin/crab')
+def main():
 
-client = crab.CRABClient()
-logger = DummyLogger()
-# print template
-# sys.exit(0)
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-o", "--output-file",
+      help="output completion file", type=str, 
+      default="etc/crab-bash-completion.sh" )
+    p_args = parser.parse_args()
 
-longnames = []
-commands = {}
-options = []
+    logging.info(p_args.output_file)
 
-for opt in client.parser.option_list:
-    options.append(opt.get_opt_string())
-    options += opt._short_opts
+    # python "imp" is deprecated, migrated to "importlib" with the help of
+    # https://stackoverflow.com/a/41595552
+    spec = importlib.util.spec_from_file_location("crab", "bin/crab.py")
+    crab = importlib.util.module_from_spec(spec)
+    sys.modules["crab"] = crab
+    spec.loader.exec_module(crab)
 
-for k, v in client.subCommands.items():
-    class DummyCmd(v):
-        def __init__(self):
-            self.parser = CRABCmdOptParser(v.name, '', False)
-            self.logger = DummyLogger()
-            self.cmdconf = commandsConfiguration.get(v.name)
+    client = crab.CRABClient()
+    logger = DummyLogger()
 
-    cmd = DummyCmd()
-    cmd.setSuperOptions()
+    longnames = []
+    commands = {}
+    options = []
 
-    flags = []
-    opts = []
+    for opt in client.parser.option_list:
+        options.append(opt.get_opt_string())
+        options += opt._short_opts
 
-    for opt in cmd.parser.option_list:
-        args = opt.nargs if opt.nargs is not None else 0
-        names = [opt.get_opt_string()] + opt._short_opts
+    for k, v in client.subCommands.items():
+        class DummyCmd(v):
+            def __init__(self):
+                self.parser = CRABCmdOptParser(v.name, '', False)
+                self.logger = DummyLogger()
+                self.cmdconf = commandsConfiguration.get(v.name)
 
-        if args == 0:
-            flags += names
-        else:
-            opts += names
+        cmd = DummyCmd()
+        cmd.setSuperOptions()
 
-    longnames.append(cmd.name)
-    for c in [cmd.name] + cmd.shortnames:
-        commands[c] = template_cmd.format(
-                cmd=c,
-                cmdflags=' '.join(flags),
-                cmdoptions=' '.join(opts))
+        flags = []
+        opts = []
 
-print(template.format(
-        topcommands=' '.join(longnames),
-        topoptions=' '.join(options),
-        commands=''.join(commands.values())))
+        for opt in cmd.parser.option_list:
+            args = opt.nargs if opt.nargs is not None else 0
+            names = [opt.get_opt_string()] + opt._short_opts
+
+            if args == 0:
+                flags += names
+            else:
+                opts += names
+
+        longnames.append(cmd.name)
+        for c in [cmd.name] + cmd.shortnames:
+            commands[c] = template_cmd.format(
+                    cmd=c,
+                    cmdflags=' '.join(flags),
+                    cmdoptions=' '.join(opts))
+
+
+    # sort the output of "crab <tab> <tab>"
+    # the higher the number the earlier a crab command is shown
+    weights = {
+        "status": 1000,
+        "tasks": 200,
+        "submit": 110,
+        "proceed": 100,
+    }
+    # current sorting as of 2024-05-14. Do we still want to keep this?
+    #checkwrite getlog checkusername checkdataset checkfile 
+    #submit getoutput resubmit kill uploadlog 
+    #remake report preparelocal createmyproxy setdatasetstatus setfilestatus
+
+    longnames_w = [(name, weights[name] if name in weights else 0) for name in longnames]
+    longnames_w = sorted(longnames_w, key=lambda x: x[1], reverse=True)
+    longnames = [l_w[0] for l_w in longnames_w]
+    logging.info(longnames)
+
+    with open(p_args.output_file, "w") as f_:
+        f_.write(template.format(
+            topcommands=' '.join(longnames),
+            topoptions=' '.join(options),
+            commands=''.join(commands.values())))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_completion.py
+++ b/scripts/generate_completion.py
@@ -1,9 +1,19 @@
 """
 
-how to use:
+This script is used to generate the file etc/crab-bash-completion.sh
+automatically from crab client code, without the need to manually edit it.
+The current crab client build process uses etc/crab-bash-completion.sh
+directly.
+
+When you change the interface of crab client, for example adding a new command
+or adding a new parameter to an existing command, you should run this script 
+with:
 
 > cd CRABClient
-> python3 scripts/generate_completions.py -o etc/crab-bash-completion.sh
+> python3 scripts/generate_completions.py
+
+This script will generate a new version of etc/crab-bash-completion.sh
+that will be used by the crab client build process.
 
 Known limitations:
 


### PR DESCRIPTION
fixes #5314 

### status

tested on my laptop, but i have a small question before merging

### solution

This PR serves multiple purposes:

- make bash autocompletion respect the order at which we provide the commands. see the use of `-o nosort` in `complete -F _UseCrab -o filenames -o nosort crab`
- do not edit the `etc/crab-bashpcimpletion.sh` directly, generate it programmatically from `scripts/generate-completions.py`
  - make `generate-completions.py` work with python3
    - use `importlib` instead of  `imp`
  - make `generate-completions.py` generate the completion in our desired ordering, see the use of the `weights` variable.

open questions:

- [ ] I did not replicate to the variable `weights` the exact sorting that we have now yet. 
  - take a look at `etc/crab-bash-completion.sh` line 26. the order here is what bash shows when you press `crab <tab><tab>` (the order of line 32 will be the same as line 26)
  - what is the exact order that we want here?

### comment 

I decided to revamp the `generate_completion.py` script because I did not want to think about adding manually all the new commands introduced with `crab recover` :)