### PR TITLE
Fix typos in output messages and subsection TWiki link for cmsenv

### DIFF
--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -205,12 +205,12 @@ def uploadlogfile(logger, proxyfilename, taskname=None, logfilename=None, logpat
     if logfilename == None:
         logfilename = str(time.strftime("%Y-%m-%d_%H%M%S"))+'_crab.log'
 
-    logger.info('Fetching user enviroment to log file')
+    logger.info('Fetching user environment to log file')
 
     try:
         logger.debug('Running env command')
         stdout, _, _ = execute_command(command='env')
-        logger.debug('\n\n\nUSER ENVIROMENT\n%s' % stdout)
+        logger.debug('\n\n\nUSER ENVIRONMENT\n%s' % stdout)
     except Exception as se:
         logger.debug('Failed to get the user env\nException message: %s' % (se))
 
@@ -554,7 +554,7 @@ def getUsernameFromCRIC(proxyFileName=None):
         msg += "\n    Parsed username: %s" % (username)
         msg += "\n%sNote%s: Make sure you have the correct certificate mapped in your CERN account page" % (colors.BOLD, colors.NORMAL)
         msg += " (you can check what is the certificate you currently have mapped"
-        msg += " by looking at CERN Certificatiom Authority page."
+        msg += " by looking at CERN Certification Authority page."
         msg += "\nFor instructions on how to map a certificate, see "
         msg += "\n  https://twiki.cern.ch/twiki/bin/view/CMSPublic/UsernameForCRAB#Adding_your_DN_to_your_profile"
         raise UsernameException(msg)

--- a/src/python/CRABClient/Commands/checkfile.py
+++ b/src/python/CRABClient/Commands/checkfile.py
@@ -46,8 +46,8 @@ class checkfile(SubCommand):
         self.checkChecksum = self.options.checkChecksum
 
         if self.checkChecksum:
-            msg = "Beware, several GB of disk space on /tmp are needed for checking replica cheksum(s)"
-            msg += "\nIf you do not have them, create the TMPDIR enviromental variable"
+            msg = "Beware, several GB of disk space on /tmp are needed for checking replica checksum(s)"
+            msg += "\nIf you do not have them, create the TMPDIR environmental variable"
             msg += "\nand point it to an existing directory of your choice\n"
             self.logger.info(msg)
 
@@ -69,7 +69,7 @@ class checkfile(SubCommand):
             if validInDBS:
                 self.logger.error("ERROR: most likely file was deleted but non invalidated in DBS")
             else:
-                self.logger.info("This is consistente with INVALID in DBS")
+                self.logger.info("This is consistent with INVALID in DBS")
             return {'commandStatus': 'SUCCESS'}
 
         # so far so good, find Replicas and check size of the disk ones

--- a/src/python/CRABClient/CredentialInteractions.py
+++ b/src/python/CRABClient/CredentialInteractions.py
@@ -68,7 +68,7 @@ class CredentialInteractions(object):
         Handles the proxy creation:
            - checks if a valid proxy still exists
            - performs the creation if it is expired
-           - returns a dictionary with keys: filename timelect actimeleft userdn
+           - returns a dictionary with keys: filename timeleft actimeleft userdn
         """
         proxyInfo = {}
         ## TODO add the change to have user-cert/key defined in the config.

--- a/src/python/CRABClient/JobType/CMSSWConfig.py
+++ b/src/python/CRABClient/JobType/CMSSWConfig.py
@@ -68,7 +68,7 @@ class CMSSWConfig(object):
             if configurationCache:
                 # check that nothing has changed, and use it
                 if not cacheLine in configurationCache:
-                    msg = "\nFATAL ERROR: A different CMSSSW configuration was already cached."
+                    msg = "\nFATAL ERROR: A different CMSSW configuration was already cached."
                     msg += "\n Either configuration file name or configuration parameters have been changed."
                     msg += "\n But CMSSW configuration files can't be loaded more than once in memory."
                     raise ConfigurationException(msg)

--- a/src/python/CRABClient/JobType/ScramEnvironment.py
+++ b/src/python/CRABClient/JobType/ScramEnvironment.py
@@ -77,8 +77,8 @@ class ScramEnvironment(dict):
             self["CMSSW_VERSION"]     = None
 #            self.cmsswReleaseBase = None
 #            self.localRT          = None
-            msg = "Please make sure you have setup the CMS enviroment (cmsenv). Cannot find %s in your env" % str(ke)
-            msg += "\nPlease refer to https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookCRAB3Tutorial#CMS_environment for how to setup the CMS enviroment."
+            msg = "Please make sure you have setup the CMS environment (cmsenv). Cannot find %s in your env" % str(ke)
+            msg += "\nPlease refer to https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookCRAB3Tutorial#Setup_the_environment for how to setup the CMS environment."
             raise EnvironmentException(msg)
 
 

--- a/src/python/CRABClient/JobType/UserTarball.py
+++ b/src/python/CRABClient/JobType/UserTarball.py
@@ -293,7 +293,7 @@ class UserTarball(object):
                    (colors.RED, colors.NORMAL, archiveSize, FILE_SIZE_LIMIT//1024//1024))
             msg += "\nlargest 5 files are:"
             msg += self.printSortedContent(maxLines=5)
-            msg += "\nsee crab.log file for full list of tarball contetnt"
+            msg += "\nsee crab.log file for full list of tarball content"
             fullList = self.printSortedContent()
             self.logger.debug(fullList)
             raise SandboxTooBigException(msg)

--- a/test/python/CRABClient_t/JobType_t/CMSSW_t.py
+++ b/test/python/CRABClient_t/JobType_t/CMSSW_t.py
@@ -139,7 +139,7 @@ class CMSSWTest(unittest.TestCase):
 
     def testValidateConfig(self):
         """
-        Validate config, done as part of the constuctor
+        Validate config, done as part of the constructor
         """
         origConfig = copy.deepcopy(testWMConfig)
 


### PR DESCRIPTION
Hello. I found some typos in python files (non-frozen). Also changed the on-page paragraph link for the cmsenv setup section that had lost its target.