### PR TITLE
report - fix bug in --recovery=failed

### DIFF
--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -187,7 +187,7 @@ class report(SubCommand):
             else:
                 notProcLumisCalcMethMsg += " minus the lumis published in the output dataset."
         elif self.options.recovery == 'failed':
-            for jobid, status in reportData['jobList']:
+            for status, jobid in reportData['jobList']:
                 if status in ['failed']:
                     for run, lumiRanges in lumisToProcessPerJob[jobid].items():
                         if run not in notProcessedLumis:


### PR DESCRIPTION
fix #5325

### status

tested, the `failedLumis.json` file is produced [1]

---

[1]:

<details>

```plaintext
Singularity> crab report -d crab_EGammaEXO_Run2018A_20240704_231147 --proxy=$X509_USER_PROXY --recovery=failed
Running crab status first to fetch necessary information.
Rucio client intialized for account dmapelli
Will save lumi files into output directory /home/dario/crab/local/z-submitted/crab_EGammaEXO_Run2018A_20240704_231147/results
Summary from jobs in status 'finished':
  Number of files processed: 2860
  Number of events read: 3848368
  Number of events written in EDM files: 0
  Number of events written in TFileService files: 0
  Number of events written in other type of files: 0
  Processed lumis written to processedLumis.json
  Warning: 'failed' lumis written to failedLumis.json
           The 'failed' lumis were calculated as: the lumis to process by jobs in status 'failed'.
Additional report lumi files:
  Input dataset lumis (from DBS, at task submission time) written to inputDatasetLumis.json
  Lumis to process written to lumisToProcess.json
Log file is /home/dario/crab/local/z-submitted/crab_EGammaEXO_Run2018A_20240704_231147/crab.log

Singularity> wc crab_EGammaEXO_Run2018A_20240704_231147/results/failedLumis.json
    1  4151 25317 crab_EGammaEXO_Run2018A_20240704_231147/results/failedLumis.json
```

</details>