### PR TITLE
Python3.12 support: Use importlib instead of deprecated imp module

### DIFF
--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -1,6 +1,5 @@
 import os
 import re
-import imp 
 import json
 import types
 from ast import literal_eval
@@ -11,7 +10,7 @@ from WMCore.Configuration import loadConfigurationFile, Configuration
 from ServerUtilities import SERVICE_INSTANCES
 
 import CRABClient.Emulator
-from CRABClient import __version__
+from CRABClient import __version__, find_module, load_module
 from CRABClient.ClientUtilities import colors
 from CRABClient.CRABOptParser import CRABCmdOptParser
 from CRABClient.CredentialInteractions import CredentialInteractions
@@ -106,12 +105,9 @@ class ConfigCommand:
         filename = os.path.abspath(configname)
         cfgBaseName = os.path.basename(filename).replace(".py", "")
         cfgDirName = os.path.dirname(filename)
-        if  not cfgDirName:
-            modPath = imp.find_module(cfgBaseName)
-        else:
-            modPath = imp.find_module(cfgBaseName, [cfgDirName])
+        modPath = find_module(cfgBaseName, cfgDirName)
         try:
-            imp.load_module(cfgBaseName, modPath[0], modPath[1], modPath[2])
+            load_module(cfgBaseName, modPath)
         except Exception as ex:
             msg = str(ex)
 

--- a/src/python/CRABClient/WMCoreConfiguration.py
+++ b/src/python/CRABClient/WMCoreConfiguration.py
@@ -28,10 +28,10 @@ https://github.com/cms-sw/cmsdist/blob/a3a1ae367973de9b5c57de3b52d8d4df27611b91/
 """
 
 from __future__ import division
-import imp
 import os
 import sys
 import traceback
+from CRABClient import find_module, load_module
 
 PY3 = sys.version_info[0] == 3
 
@@ -334,13 +334,9 @@ def loadConfigurationFile(filename):
 
     cfgBaseName = os.path.basename(filename).replace(".py", "")
     cfgDirName = os.path.dirname(filename)
-    if not cfgDirName:
-        modPath = imp.find_module(cfgBaseName)
-    else:
-        modPath = imp.find_module(cfgBaseName, [cfgDirName])
+    modPath = find_module(cfgBaseName, cfgDirName)
     try:
-        modRef = imp.load_module(cfgBaseName, modPath[0],
-                                 modPath[1], modPath[2])
+        modRef = load_module(cfgBaseName, modPath)
     except Exception as ex:
         msg = "Unable to load Configuration File:\n"
         msg += "%s\n" % filename

--- a/src/python/CRABClient/__init__.py
+++ b/src/python/CRABClient/__init__.py
@@ -5,3 +5,41 @@ CRAB Client modules
 __version__ = "development"
 
 #the __version__ will be automatically be change according to rpm for production
+
+import sys
+if (sys.version_info[0]*100+sys.version_info[1])>=312:
+    import importlib
+    def find_module(moduleName, moduleDir = None):
+        if moduleDir:
+            return importlib.machinery.PathFinder.find_spec(moduleName, [moduleDir])
+        return importlib.machinery.PathFinder.find_spec(moduleName)
+
+    def load_module(moduleName, moduleSpec):
+        moduleObj = importlib.util.module_from_spec(moduleSpec)
+        sys.modules[moduleName] = moduleObj
+        moduleSpec.loader.exec_module(moduleObj)
+        return moduleObj
+
+    def load_source(moduleName, moduleFile):
+        moduleSpec = importlib.util.spec_from_file_location(moduleName,
+                                                            moduleFile)
+        return load_module(moduleName, moduleSpec)
+
+    def module_pathname(moduleObj):
+        return moduleObj.origin
+else:
+    import imp
+    def find_module(moduleName, moduleDir = None):
+        if moduleDir:
+            return imp.find_module(moduleName, [moduleDir])
+        return imp.find_module(moduleName)
+
+    def load_module(moduleName, moduleObj):
+        return imp.load_module(moduleName, moduleObj[0],
+                               moduleObj[1], moduleObj[2])
+
+    def load_source(moduleName, moduleFile):
+        return imp.load_source(moduleName, moduleFile)
+
+    def module_pathname(moduleObj):
+        return moduleObj[1]

--- a/test/python/CRABClient_t/Commands_t/CRABRESTModelMock.py
+++ b/test/python/CRABClient_t/Commands_t/CRABRESTModelMock.py
@@ -1,9 +1,9 @@
+from CRABClient import load_source
 from WMCore.WebTools.RESTModel import RESTModel
 import WMCore
 
 import threading
 import cherrypy
-import imp
 import os
 import uuid
 import tempfile
@@ -21,7 +21,7 @@ class CRABRESTModelMock(RESTModel):
     def __init__(self, config={}):
         RESTModel.__init__(self, config)
 
-        self.mapme = imp.load_source('', os.path.join( os.path.dirname(__file__), "../../../data/mapper.py"))
+        self.mapme = load_source('', os.path.join( os.path.dirname(__file__), "../../../data/mapper.py"))
 
         self.defaulturi = self.mapme.defaulturi
 

--- a/test/python/CRABClient_t/Commands_t/Commands_t.py
+++ b/test/python/CRABClient_t/Commands_t/Commands_t.py
@@ -1,6 +1,7 @@
 import CRABRESTModelMock
 from FakeRESTServer import FakeRESTServer
 from WMCore.Configuration import Configuration
+from WMCore import load_source
 from CRABClient.Commands.server_info import server_info
 from CRABClient.Commands.getoutput import getoutput
 from CRABClient.Commands.publish import publish
@@ -19,7 +20,6 @@ import json
 import os
 import shutil
 import time
-import imp
 from socket import error as SocketError
 
 class CommandTest(FakeRESTServer):
@@ -34,7 +34,7 @@ class CommandTest(FakeRESTServer):
 
     def setUp(self):
         #Dynamic import of the configuration which in principle is not in the PYTHONPATH
-        self.TestConfig = imp.load_source('TestConfig', os.path.join( os.path.dirname(__file__), "../../../data/TestConfig.py"))
+        self.TestConfig = load_source('TestConfig', os.path.join( os.path.dirname(__file__), "../../../data/TestConfig.py"))
         FakeRESTServer.setUp(self)
         if os.path.isdir("./crab_TestAnalysis"):
             shutil.rmtree("./crab_TestAnalysis")


### PR DESCRIPTION
`imp` module has been deprecated and removed in `python 3.12`. This PR proposes to uses `importlib` for `python 3.12` e.g in `CMSSW_14_2_PY3_12_X` IBs. It should not break crab client for CMSSW release with `python version < 3.12`.

This requires newer WMCore specially change in [WMCore/Configuration.py](https://github.com/dmwm/WMCore/pull/11530/files#diff-ae418221154baa0ba96bdcf0566fde2fccf43a95d289f435f28c45e2a0552f1b) . 

Note that using this I was able to submit crab job for CMSSW_14_2_PY312_X but they [fail on crab server side](https://cmsweb.cern.ch:8443/scheddmon/0195/cmsbot/241121_102531:cmsbot_crab_Jenkins_CMSSW_14_2_PY312_X_2024-11-20-2300_el8_amd64_gcc12_123400/job_out.1.0.txt) as due to usage of `imp` in crab server code. So in order to fully support python 3.12 crab jobs, one needs to update crab server code too