### PR TITLE
make crab --version work also w/o cmsenv. Fix #5380

### DIFF
--- a/bin/crab
+++ b/bin/crab
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 script_dir=`dirname $0`
-python_cmd="python"
+python_cmd="python2"
 [ -z "$CMSSW_VERSION" ] && echo "CMSSW is missing. You must do cmsenv first" && exit
 CMSSW_Major=$(echo $CMSSW_VERSION | cut -d_ -f2)  # e.g. from CMSSW_13_1_x this is "13"
 CMSSW_Serie=$(echo $CMSSW_VERSION | cut -d_ -f3)  # e.g. from CMSSW_10_6_x this is "6"

--- a/bin/crab.py
+++ b/bin/crab.py
@@ -14,9 +14,13 @@ import logging
 import logging.handlers
 import re
 
+from CRABClient import __version__ as client_version
+if sys.argv[1] == '--version':
+    print("CRAB Client %s" % client_version)
+    sys.exit()
+
 from ServerUtilities import FEEDBACKMAIL
 from CRABClient.CRABOptParser import CRABOptParser
-from CRABClient import __version__ as client_version
 from CRABClient.ClientMapping import parametersMapping
 from CRABClient.ClientExceptions import ClientException, RESTInterfaceException, CommandFailedException
 from CRABClient.ClientUtilities import getAvailCommands, initLoggers, setConsoleLogLevelVar, StopExecution, flushMemoryLogger, LOGFORMATTER


### PR DESCRIPTION
still requires $CMSSW_VERSION to be defined