### PR TITLE
make submit dryrun work with TW v3.250401 Fix #5383

### DIFF
--- a/src/python/CRABClient/Commands/submit.py
+++ b/src/python/CRABClient/Commands/submit.py
@@ -417,7 +417,7 @@ class submit(SubCommand):
         try:
             #tmpDir = tempfile.mkdtemp()
             #self.logger.info('Created temporary directory for dry run sandbox in %s' % tmpDir)
-            self.logger.info('Execute rest run in local sub-directory of %s', projDir)
+            self.logger.info('Execute test run in local sub-directory of %s', projDir)
             os.chdir(os.path.join(projDir, 'local'))
             #downloadFromS3(crabserver=self.crabserver, filepath=os.path.join(tmpDir, 'dry-run-sandbox.tar.gz'),
             #               objecttype='runtimefiles', taskname=uniquerequestname, logger=self.logger)
@@ -545,8 +545,8 @@ def setCMSRunAnalysisOpts(events=10):
     Parse the job ad to obtain the arguments that were passed to condor.
     """
 
-    with open('JobArgs-1.json', 'r') as f:
-        args = json.load(f)
+    with open('input_args.json', 'r') as f:  # this file contains args for all jobs
+        args = json.load(f)[0]               # pick job #1
     args.update({'CRAB_Id': '0', 'firstEvent': '1', 'lastEvent': str(int(events) + 1)})
     with open('DryRunJobArg.json', 'w') as f:
         json.dump(args, f)


### PR DESCRIPTION
after this:
```console
belforte@lxplus813/TC3> crab submit --dryrun 
Will use CRAB configuration file crabConfig.py
Importing CMSSW configuration dummyanalyzer.py
Finished importing CMSSW configuration dummyanalyzer.py
Sending the request to the server at cmsweb.cern.ch
Success: Your task has been delivered to the prod CRAB3 server.
Task name: 250409_151806:belforte_crab_20250409_171801
Project dir: ./crab_20250409_171801
Waiting for task to be processed
Checking task status
Task status: WAITING
Please wait...
Task status: NEW
Please wait...
Task status: UPLOADED

Dry run
Getting input files into tmp dir /tmp/belforte/tmpk4p3vqb_
Copying and preparing files for local execution in /afs/cern.ch/work/b/belforte/CRAB3/TC3/crab_20250409_171801/local
go to that directory IN A CLEAN SHELL and use  'sh run_job.sh NUMJOB' to execute the job
Execute rest run in local sub-directory of ./crab_20250409_171801
Executing test, please wait...
Last trial took only 9.5 seconds. We are trying now with 216 events
Last trial took only 16.7 seconds. We are trying now with 932 events

Using LumiBased splitting
Task consists of 30 jobs to process 300 lumis
The longest job will process 10 lumis, with an estimated processing time of 1 minutes
The average job will process 10 lumis, with an estimated processing time of 1 minutes
The shortest job will process 10 lumis, with an estimated processing time of 1 minutes
The estimated memory requirement is 1248 MB

Timing quantities given below are ESTIMATES. Keep in mind that external factors
such as transient file-access delays can reduce estimate reliability.

For ~480 minute jobs, use:
Data.unitsPerJob = 3459
You will need to submit a new task

Dry run requested: task paused
To continue processing, use 'crab proceed'

Log file is /afs/cern.ch/work/b/belforte/CRAB3/TC3/crab_20250409_171801/crab.log
belforte@lxplus813/TC3> 
```