### PR TITLE
Rest Interface curl parsing allowing HTTP2

### DIFF
--- a/src/python/CRABClient/RestInterfaces.py
+++ b/src/python/CRABClient/RestInterfaces.py
@@ -58,9 +58,9 @@ def parseResponseHeader(response):
     Parse response header and return HTTP code with reason
     Example taken from WMCore pycurl_manager
     """
-    startRegex = r"HTTP\/\d.\d\s\d{3}[^\n]*"
-    continueRegex = r"HTTP\/\d.\d\s100[^\n]*"  # Continue: client should continue its request
-    replaceRegex = r"HTTP\/\d.\d"
+    startRegex = r"HTTP/\d(?:\.\d)?\s\d{3}[^\n]*"
+    continueRegex = r"HTTP/\d(?:\.\d)?\s100[^\n]*"  # Continue: client should continue its request
+    replaceRegex = r"HTTP/\d(?:\.\d)?"
 
     reason = ''
     code = 9999
@@ -73,9 +73,9 @@ def parseResponseHeader(response):
             if re.search(continueRegex, row):
                 continue
             res = re.sub(replaceRegex, "", response.group(0)).strip()
-            code, reason = res.split(' ', 1)
-            code = int(code)
-
+            parts = res.split(' ', 1)
+            code = int(parts[0])
+            reason = parts[1] if len(parts) > 1 else ''
     return code, reason
 
 

--- a/src/python/CRABClient/RestInterfaces.py
+++ b/src/python/CRABClient/RestInterfaces.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     from urllib.parse import quote as urllibQuote  # Python 3+
 
+import http
+
 from CRABClient.ClientUtilities import execute_command
 from ServerUtilities import encodeRequest
 from CRABClient.ClientExceptions import RESTInterfaceException, ConfigurationException
@@ -75,7 +77,7 @@ def parseResponseHeader(response):
             res = re.sub(replaceRegex, "", response.group(0)).strip()
             parts = res.split(' ', 1)
             code = int(parts[0])
-            reason = parts[1] if len(parts) > 1 else ''
+            reason = parts[1] if len(parts) > 1 else http.HTTPStatus(code).phrase
     return code, reason
 
 


### PR DESCRIPTION
This PR weakens the conditions of the RegEx used to parse HTTP responses from the server (that at the moment requires a ".<minor version>" after HTTP), avoiding failures for HTTP2, which:
- may not have minor version
- don't provide reason next to the status code

A status code is generated from the http library, when missing.

Example outputs:
``` bash
2025-09-05 10:53 lvalenti@lxplus9106:~$ curl -v --http1.1 --cert /tmp/x509up_u156194 --key /tmp/x509up_u156194 -k https://cmsweb.cern.ch/crabserver/prod/info 2>&1 1>/dev/null | python3 parser.py
HTTP code=200, reason='OK'
2025-09-05 10:53 lvalenti@lxplus9106:~$ curl -v --http1.1 --cert /tmp/x509up_u156194 --key /tmp/x509up_u156194 -k https://cmsweb.cern.ch/crabserver/prod/fakeendpoint 2>&1 1>/dev/null | python3 parser.py
HTTP code=404, reason='Not Found'
2025-09-05 10:53 lvalenti@lxplus9106:~$ curl -v --http2 --cert /tmp/x509up_u156194 --key /tmp/x509up_u156194 -k https://cmsweb.cern.ch/crabserver/prod/fakeendpoint 2>&1 1>/dev/null | python3 parser.py
HTTP code=404, reason='Not Found'
2025-09-05 10:54 lvalenti@lxplus9106:~$ curl -v --http2 --cert /tmp/x509up_u156194 --key /tmp/x509up_u156194 -k https://cmsweb.cern.ch/crabserver/prod/info 2>&1 1>/dev/null | python3 parser.py
HTTP code=200, reason='OK'
```

Example of crab failing with HTTP2 due to the parser:
```
INFO:CRAB3.all:Fatal error trying to connect to https://cmsweb.cern.ch:8443/crabserver/prod/info?subresource=version using subresource=version.
exit code from curl = 0
HTTP code/reason = 9999/ .  stdout:
{"result": [
 ["3.3.19", "3.3.20", "v3", "development", "v3.250401"]
]}

Traceback (most recent call last):
  File "/data/hc/scr2.py", line 56, in <module>
    result = crabCommand('submit', config=config, proxy=proxy_path)
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABAPI/RawCommand.py", line 28, in crabCommand
    return execRaw(command, arguments)
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABAPI/RawCommand.py", line 51, in execRaw
    cmdobj = getattr(mod, command)(logger, args)
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/Commands/submit.py", line 37, in __init__
    SubCommand.__init__(self, logger, cmdargs, disable_interspersed_args=True)
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/Commands/SubCommand.py", line 409, in __init__
    self.checkversion()
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/Commands/SubCommand.py", line 455, in checkversion
    compatibleVersions = server_info(crabserver=self.crabserver, subresource='version')
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/ClientUtilities.py", line 692, in server_info
    dictresult, dummyStatus, dummyReason = crabserver.get(api, requestdict)
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/RestInterfaces.py", line 279, in get
    return self.server.get(uri, data)
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/RestInterfaces.py", line 121, in get
    return self.makeRequest(uri=uri, data=data, verb='GET')
  File "/cvmfs/cms.cern.ch/share/cms/crab-prod/v3.250522.00/lib/CRABClient/RestInterfaces.py", line 225, in makeRequest
    raise RESTInterfaceException(stderr)
CRABClient.ClientExceptions.RESTInterfaceException:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 188.185.89.194:8443...
* Connected to cmsweb.cern.ch (188.185.89.194) port 8443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
*  CAfile: /etc/pki/tls/certs/ca-bundle.crt
*  CApath: /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/etc/grid-security-emi/certificates
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
} [512 bytes data]
* TLSv1.2 (IN), TLS header, Certificate Status (22):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* TLSv1.2 (IN), TLS header, Finished (20):
{ [5 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
{ [15 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
{ [7807 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Certificate (11):
{ [2064 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* TLSv1.2 (OUT), TLS header, Finished (20):
} [5 bytes data]
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
} [9958 bytes data]
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, CERT verify (15):
} [264 bytes data]
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* TLSv1.3 (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: DC=ch; DC=cern; OU=computers; CN=cmsweb.cern.ch
*  start date: May  6 09:49:35 2025 GMT
*  expire date: Jun 10 09:49:35 2026 GMT
*  subjectAltName: host "cmsweb.cern.ch" matched cert's "cmsweb.cern.ch"
*  issuer: DC=ch; DC=cern; CN=CERN Grid Certification Authority
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* Using Stream ID: 1 (easy handle 0x55b9a1cb8150)
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
> GET /crabserver/prod/info?subresource=version HTTP/2
> Host: cmsweb.cern.ch:8443
> user-agent: CRABClient/v3.250522
> accept: */*
> content-length: 19
> content-type: application/x-www-form-urlencoded
> 
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [10072 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* TLSv1.2 (OUT), TLS header, Unknown (23):
} [5 bytes data]
* We are completely uploaded and fine
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
< HTTP/2 200 
< cache-control: max-age=3600
< content-type: application/json
< date: Mon, 21 Jul 2025 07:41:36 GMT
< etag: "f121869c5a7547c1fb4ab8b0d5f17cb630de6d4e"
< response-proto: HTTP/1.1
< response-status: 200 OK
< response-status-code: 200
< response-time: 4.578157ms
< response-time-seconds: 0.004578663
< vary: Accept, Accept-Encoding
< x-content-type-options: bla
< x-rest-status: 100
< x-rest-time: 1632.929 us
< content-length: 72
< 
* TLSv1.2 (IN), TLS header, Unknown (23):
{ [5 bytes data]
100    91  100    72  100    19   2666    703 --:--:-- --:--:-- --:--:--  3370
* Connection #0 to host cmsweb.cern.ch left intact
{"result": [
 ["3.3.19", "3.3.20", "v3", "development", "v3.250401"]
]}
```


