### PR TITLE
py2 compatible HTTPStatus imported.

### DIFF
--- a/src/python/CRABClient/RestInterfaces.py
+++ b/src/python/CRABClient/RestInterfaces.py
@@ -16,7 +16,8 @@ import logging
 try:
     # Python 2.X
     from urllib import quote as urllibQuote
-    import httplib as _http_client  # pylint: disable=import-error
+    import httplib as _http_client
+    # add an HTTPStatus class such that it can be used like http which is only available in python3
     class HTTPStatus(int):
         _responses = getattr(_http_client, "responses", {})
         def __new__(cls, code):
@@ -27,7 +28,7 @@ try:
 except ImportError:
     # Python 3+
     from urllib.parse import quote as urllibQuote
-    from http import HTTPStatus # pylint: disable=import-error
+    from http import HTTPStatus
 
 from CRABClient.ClientUtilities import execute_command
 from ServerUtilities import encodeRequest

--- a/src/python/CRABClient/RestInterfaces.py
+++ b/src/python/CRABClient/RestInterfaces.py
@@ -15,10 +15,17 @@ import logging
 
 try:
     from urllib import quote as urllibQuote  # Python 2.X
+    import httplib as _http_client
+    class HTTPStatus(int):
+        _responses = getattr(_http_client, "responses", {})
+        def __new__(cls, code):
+            return int.__new__(cls, int(code))
+        @property
+        def phrase(self):
+            return self._responses.get(int(self), "Unknown Status")
 except ImportError:
     from urllib.parse import quote as urllibQuote  # Python 3+
-
-import http
+    from http import HTTPStatus
 
 from CRABClient.ClientUtilities import execute_command
 from ServerUtilities import encodeRequest
@@ -77,7 +84,7 @@ def parseResponseHeader(response):
             res = re.sub(replaceRegex, "", response.group(0)).strip()
             parts = res.split(' ', 1)
             code = int(parts[0])
-            reason = parts[1] if len(parts) > 1 else http.HTTPStatus(code).phrase
+            reason = parts[1] if len(parts) > 1 else HTTPStatus(code).phrase
     return code, reason
 
 

--- a/src/python/CRABClient/RestInterfaces.py
+++ b/src/python/CRABClient/RestInterfaces.py
@@ -14,8 +14,9 @@ import tempfile
 import logging
 
 try:
-    from urllib import quote as urllibQuote  # Python 2.X
-    import httplib as _http_client
+    # Python 2.X
+    from urllib import quote as urllibQuote
+    import httplib as _http_client  # pylint: disable=import-error
     class HTTPStatus(int):
         _responses = getattr(_http_client, "responses", {})
         def __new__(cls, code):
@@ -24,8 +25,9 @@ try:
         def phrase(self):
             return self._responses.get(int(self), "Unknown Status")
 except ImportError:
-    from urllib.parse import quote as urllibQuote  # Python 3+
-    from http import HTTPStatus
+    # Python 3+
+    from urllib.parse import quote as urllibQuote
+    from http import HTTPStatus # pylint: disable=import-error
 
 from CRABClient.ClientUtilities import execute_command
 from ServerUtilities import encodeRequest


### PR DESCRIPTION
Resolve #5416 

I've tested on all slc6 env (e.g. `CMSSW_10_1_0`, `CMSSW_9_4_21`, `CMSSW_8_0_36`). Status responses are fine for every status codes, also in case of unknown one.