### PR TITLE
[PEP389] introduce argparse deprecate optparse

### DIFF
--- a/bin/crab.py
+++ b/bin/crab.py
@@ -60,7 +60,7 @@ class CRABClient(object):
 
     def __call__(self):
 
-        (options, args) = self.parser.parse_args()
+        (options, args) = self.parser.parse_cmd()
 
         ## The default logfile destination is ./crab.log. It will be changed once we
         ## know/create the CRAB project directory.

--- a/doc/generate_modules.py
+++ b/doc/generate_modules.py
@@ -232,7 +232,7 @@ def main():
     """
     Parse and check the command line arguments.
     """
-    parser = argparse.ArgumentParser(usage="""usage: %prog [options] <package path> [exclude paths, ...]
+    parser = argparse.ArgumentParser(usage="""usage: %(prog)s, [options] <package path> [exclude paths, ...]
 
 Note: By default this script will not overwrite already created files.""")
     parser.add_argument("-n", "--doc-header", action="store", dest="header", help="Documentation Header (default=Project)", default="Project")

--- a/doc/generate_modules.py
+++ b/doc/generate_modules.py
@@ -28,7 +28,7 @@ from __future__ import print_function
 
 
 import os
-import optparse
+import argparse
 
 
 # automodule options
@@ -232,17 +232,17 @@ def main():
     """
     Parse and check the command line arguments.
     """
-    parser = optparse.OptionParser(usage="""usage: %prog [options] <package path> [exclude paths, ...]
+    parser = argparse.ArgumentParser(usage="""usage: %prog [options] <package path> [exclude paths, ...]
 
 Note: By default this script will not overwrite already created files.""")
-    parser.add_option("-n", "--doc-header", action="store", dest="header", help="Documentation Header (default=Project)", default="Project")
-    parser.add_option("-d", "--dest-dir", action="store", dest="destdir", help="Output destination directory", default="")
-    parser.add_option("-s", "--suffix", action="store", dest="suffix", help="module suffix (default=txt)", default="txt")
-    parser.add_option("-m", "--maxdepth", action="store", dest="maxdepth", help="Maximum depth of submodules to show in the TOC (default=4)", type="int", default=4)
-    parser.add_option("-r", "--dry-run", action="store_true", dest="dryrun", help="Run the script without creating the files")
-    parser.add_option("-f", "--force", action="store_true", dest="force", help="Overwrite all the files")
-    parser.add_option("-t", "--no-toc", action="store_true", dest="notoc", help="Don't create the table of content file")
-    (opts, args) = parser.parse_args()
+    parser.add_argument("-n", "--doc-header", action="store", dest="header", help="Documentation Header (default=Project)", default="Project")
+    parser.add_argument("-d", "--dest-dir", action="store", dest="destdir", help="Output destination directory", default="")
+    parser.add_argument("-s", "--suffix", action="store", dest="suffix", help="module suffix (default=txt)", default="txt")
+    parser.add_argument("-m", "--maxdepth", action="store", dest="maxdepth", help="Maximum depth of submodules to show in the TOC (default=4)", type=int, default=4)
+    parser.add_argument("-r", "--dry-run", action="store_true", dest="dryrun", help="Run the script without creating the files")
+    parser.add_argument("-f", "--force", action="store_true", dest="force", help="Overwrite all the files")
+    parser.add_argument("-t", "--no-toc", action="store_true", dest="notoc", help="Don't create the table of content file")
+    opts, args = parser.parse_known_args()
     if not args:
         parser.error("package path is required.")
     else:

--- a/src/python/CRABAPI/RawCommand.py
+++ b/src/python/CRABAPI/RawCommand.py
@@ -33,7 +33,7 @@ def execRaw(command, args):
     """
         execRaw - executes a given command with certain arguments and returns
                   the raw result back from the client. args is a python list,
-                  the same python list parsed by the optparse module
+                  the same python list parsed by the argument parser
                   Every command returns a dictionary of the form
                   {'commandStatus': status, key: val, key: val ....}
                   where status can have the values 'SUCCESS' or 'FAILED'
@@ -51,7 +51,7 @@ def execRaw(command, args):
         cmdobj = getattr(mod, command)(logger, args)
         res = cmdobj()
     except SystemExit as se:
-        # most likely an error from the OptionParser in Subcommand.
+        # most likely an error from argument parsing in Subcommand.
         # CRABClient #4283 should make this less ugly
         if se.code == 2:
             raise CRABAPI.BadArgumentException

--- a/src/python/CRABAPI/__init__.py
+++ b/src/python/CRABAPI/__init__.py
@@ -13,7 +13,7 @@ class APIException(Exception):
 
 class BadArgumentException(APIException):
     """
-        BadArgumentException - Arguments passed didn't pass optparse's muster
+        BadArgumentException - Arguments passed didn't pass argument parsing
     """
     pass
 

--- a/src/python/CRABClient/CRABOptParser.py
+++ b/src/python/CRABClient/CRABOptParser.py
@@ -57,7 +57,7 @@ class CRABOptParser(CRABArgParser):
             epilog += '\nFor more information on how to run CRAB-3 please follow this link:\n'
             epilog += 'https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookCRAB3Tutorial\n'
 
-        CRABArgParser.__init__(self, usage=usage, epilog=epilog, disable_interspersed=True)
+        CRABArgParser.__init__(self, usage=usage, epilog=epilog, disable_interspersed_args=True)
 
         self.add_argument("--version", action="version", version="CRAB client %s" % client_version)
         self.add_argument( "--quiet",
@@ -90,7 +90,7 @@ class CRABCmdOptParser(CRABArgParser):
             description=doc,
             usage=usage,
             add_help=True,
-            disable_interspersed=disable_interspersed_args
+            disable_interspersed_args=disable_interspersed_args
         )
 
     def addCommonOptions(self, cmdconf):

--- a/src/python/CRABClient/CRABOptParser.py
+++ b/src/python/CRABClient/CRABOptParser.py
@@ -1,13 +1,38 @@
 # silence pylint complaints about things we need for Python 2.6 compatibility
 # pylint: disable=unspecified-encoding, raise-missing-from, consider-using-f-string
 
-from optparse import OptionParser  # pylint: disable=deprecated-module
+import sys
+from argparse import ArgumentParser
 
 from ServerUtilities import SERVICE_INSTANCES
 from CRABClient import __version__ as client_version
 
+def _split_at_first_positional(argv):
+    for i, tok in enumerate(argv):
+        if tok == "--":
+            return argv[:i+1], argv[i+1:]  # keep -- with options side
+        if tok == "-" or not tok.startswith("-"):
+            return argv[:i], argv[i:]
+    return argv, []
 
-class CRABOptParser(OptionParser):
+class CRABArgParser(ArgumentParser):
+    def __init__(self, *args, disable_interspersed_args=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._disable_interspersed_args = disable_interspersed_args
+
+    def parse_cmd(self, argv=None):
+        argv = list(sys.argv[1:] if argv is None else argv)
+
+        if not self._disable_interspersed_args:
+            ns, rest = self.parse_known_args(argv)
+            return ns, rest
+
+        opt_argv, rest = _split_at_first_positional(argv)
+        ns = self.parse_args(opt_argv)
+        return ns, rest
+
+
+class CRABOptParser(CRABArgParser):
     """
     Allows to make OptionParser behave how we prefer
     """
@@ -19,7 +44,7 @@ class CRABOptParser(OptionParser):
 
             subCommands: if present used to prepare a nice help summary for all the commands
         """
-        usage  = "usage: %prog [options] COMMAND [command-options] [args]"
+        usage = "usage: %(prog)s [options] COMMAND [command-options] [args]"
         epilog = ""
         if subCommands:
             epilog = '\nValid commands are: \n'
@@ -32,50 +57,41 @@ class CRABOptParser(OptionParser):
             epilog += '\nFor more information on how to run CRAB-3 please follow this link:\n'
             epilog += 'https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookCRAB3Tutorial\n'
 
-        OptionParser.__init__(self, usage   = usage, epilog  = epilog,
-                                version = "CRAB client %s" % client_version
-                             )
+        CRABArgParser.__init__(self, usage=usage, epilog=epilog, disable_interspersed=True)
 
-        # This is the important bit
-        self.disable_interspersed_args()
-
-        self.add_option( "--quiet",
+        self.add_argument("--version", action="version", version="CRAB client %s" % client_version)
+        self.add_argument( "--quiet",
                                 action = "store_true",
                                 dest = "quiet",
                                 default = False,
                                 help = "don't print any messages to stdout" )
 
-        self.add_option( "--debug",
+        self.add_argument( "--debug",
                                 action = "store_true",
                                 dest = "debug",
                                 default = False,
                                 help = "print extra messages to stdout" )
 
 
-    def format_epilog(self, formatter):
-        """
-        do not strip the new lines from the epilog
-        """
-        return self.epilog
-
-
-
-class CRABCmdOptParser(OptionParser):
+class CRABCmdOptParser(CRABArgParser):
     """ A class that extract the pieces for parsing the command line arguments
         of the CRAB commands.
 
     """
 
-    def __init__(self, cmdname, doc, disable_interspersed_args):
+    def __init__(self, cmdname, doc, disable_interspersed_args=False):
         """
             doc:        the description of the command. Taken from self.__doc__
             disable_interspersed_args: some commands (e.g.: submit) allow to overwrite configuration parameters
         """
-        usage = "usage: %prog " + cmdname + " [options] [args]"
-        OptionParser.__init__(self, description = doc, usage = usage, add_help_option = True)
-        if disable_interspersed_args:
-            self.disable_interspersed_args()
-
+        usage = "usage: %(prog)s " + cmdname + " [options] [args]"
+        CRABArgParser.__init__(
+            self,
+            description=doc,
+            usage=usage,
+            add_help=True,
+            disable_interspersed=disable_interspersed_args
+        )
 
     def addCommonOptions(self, cmdconf):
         """
@@ -86,35 +102,35 @@ class CRABCmdOptParser(OptionParser):
             a value is not indicated anywhere by the user is defined in ClientMapping.py
         """
         if cmdconf['requiresDirOption']:
-            self.add_option("-d", "--dir",
-                                   dest = "projdir",
-                                   default = None,
-                                   help = "Path to the CRAB project directory for which the crab command should be executed.")
-            self.add_option("--task",
-                                dest = "cmptask",
-                                default = None,
-                                help = "In alternative to -d, a complete task name. Can be taken from 'crab status' output, or from dashboard.")
+            self.add_argument("-d", "--dir",
+                              dest="projdir",
+                              default=None,
+                              help="Path to the CRAB project directory for which the crab command should be executed.")
+            self.add_argument("--task",
+                              dest="cmptask",
+                              default=None,
+                              help="In alternative to -d, a complete task name. Can be taken from 'crab status' output, or from dashboard.")
 
         if cmdconf['requiresREST']:
-            self.add_option("--instance",
-                                   dest = "instance",
-                                   type = "string",
-                                   default = None,
-                                   help = "Running instance of CRAB service." \
-                                          " Needed whenever --task is used." \
-                                          " Default value is 'prod'. " \
-                                          " Valid values are %s." \
-                                          % str(list(SERVICE_INSTANCES.keys())) )
+            self.add_argument("--instance",
+                              dest="instance",
+                              type=str,
+                              default=None,
+                              help="Running instance of CRAB service."
+                                   " Needed whenever --task is used."
+                                   " Default value is 'prod'. "
+                                   " Valid values are %s."
+                                   % str(list(SERVICE_INSTANCES.keys())))
 
         if cmdconf['requiresProxyVOOptions']:
-            self.add_option("--voRole",
-                                   dest = "voRole",
-                                   default = None)
-            self.add_option("--voGroup",
-                                   dest = "voGroup",
-                                   default = None)
+            self.add_argument("--voRole",
+                              dest="voRole",
+                              default=None)
+            self.add_argument("--voGroup",
+                              dest="voGroup",
+                              default=None)
 
-        self.add_option("--proxy",
-                        dest="proxy",
-                        default=False,
-                        help="Use the given proxy. Skip Grid proxy creation and myproxy delegation.")
+        self.add_argument("--proxy",
+                          dest="proxy",
+                          default=False,
+                          help="Use the given proxy. Skip Grid proxy creation and myproxy delegation.")

--- a/src/python/CRABClient/CRABOptParser.py
+++ b/src/python/CRABClient/CRABOptParser.py
@@ -7,13 +7,44 @@ from argparse import ArgumentParser
 from ServerUtilities import SERVICE_INSTANCES
 from CRABClient import __version__ as client_version
 
-def _split_at_first_positional(argv):
-    for i, tok in enumerate(argv):
+def _split_at_first_positional(parser, argv):
+    """
+    Emulate optparse.disable_interspersed_args:
+    parse options only until the first positional token, consuming option values.
+    """
+    idx = 0
+    size = len(argv)
+    while idx < size:
+        tok = argv[idx]
         if tok == "--":
-            return argv[:i+1], argv[i+1:]  # keep -- with options side
+            idx += 1
+            break
         if tok == "-" or not tok.startswith("-"):
-            return argv[:i], argv[i:]
-    return argv, []
+            break
+
+        optname = tok.split("=", 1)[0] if tok.startswith("--") else tok
+        action = parser._option_string_actions.get(optname)  # pylint: disable=protected-access
+        idx += 1
+        if action is None:
+            continue
+        if tok.startswith("--") and "=" in tok:
+            continue
+
+        nargs = action.nargs
+        if nargs in (None, 1):
+            if idx < size:
+                idx += 1
+        elif nargs in (0,):
+            continue
+        elif nargs == "?":
+            if idx < size and not argv[idx].startswith("-"):
+                idx += 1
+        elif isinstance(nargs, int):
+            idx += nargs
+        else:
+            idx = size
+
+    return argv[:idx], argv[idx:]
 
 class CRABArgParser(ArgumentParser):
     def __init__(self, *args, disable_interspersed_args=False, **kwargs):
@@ -24,10 +55,21 @@ class CRABArgParser(ArgumentParser):
         argv = list(sys.argv[1:] if argv is None else argv)
 
         if not self._disable_interspersed_args:
-            ns, rest = self.parse_known_args(argv)
-            return ns, rest
+            if "--" in argv:
+                marker = argv.index("--")
+                parseable = argv[:marker]
+                tail = argv[marker + 1:]
+            else:
+                parseable = argv
+                tail = []
 
-        opt_argv, rest = _split_at_first_positional(argv)
+            ns, rest = self.parse_known_args(parseable)
+            unknown = [arg for arg in rest if arg.startswith("-") and arg != "-"]
+            if unknown:
+                self.error("no such option: %s" % unknown[0])
+            return ns, rest + tail
+
+        opt_argv, rest = _split_at_first_positional(self, argv)
         ns = self.parse_args(opt_argv)
         return ns, rest
 

--- a/src/python/CRABClient/ClientUtilities.py
+++ b/src/python/CRABClient/ClientUtilities.py
@@ -634,26 +634,26 @@ def setSubmitParserOptions(parser):
     """ Set the option for the parser of the submit command.
         Method put here in the utilities since it is shared between the submit command and the crab3bootstrap script.
     """
-    parser.add_option('-c', '--config',
+    parser.add_argument('-c', '--config',
                            dest='config',
                            default=None,
                            help="CRAB configuration file.",
                            metavar='FILE')
 
-    parser.add_option('--wait',
+    parser.add_argument('--wait',
                            dest='wait',
                            default=False,
                            action='store_true',
                            help="DEPRECATED.")
 
-    parser.add_option('--dryrun',
+    parser.add_argument('--dryrun',
                            dest='dryrun',
                            default=False,
                            action='store_true',
                            help="Do not actually submit the task; instead, return how many jobs this task would create, "\
                                   "along with processing time and memory consumption estimates.")
 
-    parser.add_option('--skip-estimates',
+    parser.add_argument('--skip-estimates',
                            dest='skipEstimates',
                            default=False,
                            action='store_true',

--- a/src/python/CRABClient/Commands/SubCommand.py
+++ b/src/python/CRABClient/Commands/SubCommand.py
@@ -272,7 +272,7 @@ class SubCommand(ConfigCommand):
         # Parse the command options/arguments.
         cmdargs = cmdargs or []
         self.cmdargs = cmdargs
-        (self.options, self.args) = self.parser.parse_args(cmdargs)
+        (self.options, self.args) = self.parser.parse_cmd(cmdargs)
 
         self.transferringIds = None
         self.dest = None

--- a/src/python/CRABClient/Commands/checkdataset.py
+++ b/src/python/CRABClient/Commands/checkdataset.py
@@ -273,11 +273,11 @@ class checkdataset(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--dataset',
+        self.parser.add_argument('--dataset',
                                dest='dataset',
                                default=None,
                                help='dataset of block ID or Rucio DID (scope:name)')
-        self.parser.add_option('--dbs-instance', dest='dbsInstance', default='prod/global',
+        self.parser.add_argument('--dbs-instance', dest='dbsInstance', default='prod/global',
                                help="DBS instance. e.g. prod/global (default) or prod/phys03 or full URL."
                                     + "\nUse at your own risk only if you really know what you are doing"
                                )

--- a/src/python/CRABClient/Commands/checkfile.py
+++ b/src/python/CRABClient/Commands/checkfile.py
@@ -302,19 +302,19 @@ class checkfile(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--lfn',
+        self.parser.add_argument('--lfn',
                                dest='lfn',
                                default=None,
                                help='LFN of the file to check')
-        self.parser.add_option('--checksum',
+        self.parser.add_argument('--checksum',
                                dest='checkChecksum',
                                action="store_true",
                                help="check checksum of all disk replicas. SLOW and needs GB's of disk !")
-        self.parser.add_option('--dbs-instance', dest='dbsInstance', default='prod/global',
+        self.parser.add_argument('--dbs-instance', dest='dbsInstance', default='prod/global',
                                help="DBS instance. e.g. prod/global (default) or prod/phys03 or full URL."
                                     + "\nUse at your own risk only if you really know what you are doing"
                                )
-        self.parser.add_option('--rucio-scope', dest='scope', default=None,
+        self.parser.add_argument('--rucio-scope', dest='scope', default=None,
                                help="Rucio scope. Default is 'cms' for global DBS and 'user:username' for phys03"
                                )
 

--- a/src/python/CRABClient/Commands/checkwrite.py
+++ b/src/python/CRABClient/Commands/checkwrite.py
@@ -326,20 +326,20 @@ exit(0)
 
         This allows to set specific command options
         """
-        self.parser.add_option('--site',
+        self.parser.add_argument('--site',
                                dest='sitename',
                                default=None,
                                help='The PhEDEx node name of the site to be checked.')
-        self.parser.add_option('--lfn',
+        self.parser.add_argument('--lfn',
                                dest='userlfn',
                                default=None,
                                help='A user lfn address.')
-        self.parser.add_option('--checksum',
+        self.parser.add_argument('--checksum',
                                dest='checksum',
                                default='no',
                                help='Set it to yes if needed. It will use ADLER32 checksum' +\
                                        'Allowed values are yes/no. Default is no.')
-        self.parser.add_option('--command',
+        self.parser.add_argument('--command',
                                dest='command',
                                default=None,
                                help='A command which to use. Available commands are LCG or GFAL.')

--- a/src/python/CRABClient/Commands/createmyproxy.py
+++ b/src/python/CRABClient/Commands/createmyproxy.py
@@ -49,10 +49,10 @@ class createmyproxy(SubCommand):
         This allows to set specific command options.
         """
 
-        self.parser.add_option('--days',
+        self.parser.add_argument('--days',
                                dest='days',
                                default=30,
-                               type='int',
+                               type=int,
                                help="Set the validity (in days) for the credential. Default is 30.")
 
     #def terminate(self, exitcode):

--- a/src/python/CRABClient/Commands/getcommand.py
+++ b/src/python/CRABClient/Commands/getcommand.py
@@ -242,35 +242,35 @@ class getcommand(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--outputpath',
+        self.parser.add_argument('--outputpath',
                                dest='outputpath',
                                default=None,
                                help='Where the files retrieved will be stored.  Defaults to the results/ directory.',
                                metavar='URL')
 
-        self.parser.add_option('--dump',
+        self.parser.add_argument('--dump',
                                dest='dump',
                                default=False,
                                action='store_true',
                                help='Instead of performing the transfer, dump the source URLs.')
 
-        self.parser.add_option('--xrootd',
+        self.parser.add_argument('--xrootd',
                                dest='xroot',
                                default=False,
                                action='store_true',
                                help='Give XrootD url for the file.')
 
-        self.parser.add_option('--jobids',
+        self.parser.add_argument('--jobids',
                                dest='jobids',
                                default=None,
                                help='Ids of the jobs you want to retrieve. Comma separated list of integers.',
                                metavar='JOBIDS')
-        self.parser.add_option('--checksum',
+        self.parser.add_argument('--checksum',
                                dest='checksum',
                                default='yes',
                                help='Set it to yes if needed. It will use ADLER32 checksum' +\
                                        'Allowed values are yes/no. Default is yes.')
-        self.parser.add_option('--command',
+        self.parser.add_argument('--command',
                                dest='command',
                                default=None,
                                help='A command which to use. Available commands are LCG or GFAL.')

--- a/src/python/CRABClient/Commands/getlog.py
+++ b/src/python/CRABClient/Commands/getlog.py
@@ -62,16 +62,16 @@ class getlog(getcommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--quantity',
+        self.parser.add_argument('--quantity',
                                dest='quantity',
                                help='The number of logs you want to retrieve (or "all"). Ignored if --jobids is used.')
-        self.parser.add_option('--parallel',
+        self.parser.add_argument('--parallel',
                                dest='nparallel',
                                help='Number of parallel download, default is 10 parallel download.',)
-        self.parser.add_option('--wait',
+        self.parser.add_argument('--wait',
                                dest='waittime',
                                help='Increase the sendreceive-timeout in second.',)
-        self.parser.add_option('--short',
+        self.parser.add_argument('--short',
                                dest='short',
                                default=False,
                                action='store_true',

--- a/src/python/CRABClient/Commands/getoutput.py
+++ b/src/python/CRABClient/Commands/getoutput.py
@@ -24,13 +24,13 @@ class getoutput(getcommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option( '--quantity',
+        self.parser.add_argument( '--quantity',
                                 dest = 'quantity',
                                 help = 'The number of output files you want to retrieve (or "all"). Ignored if --jobids is used.' )
-        self.parser.add_option( '--parallel',
+        self.parser.add_argument( '--parallel',
                                 dest = 'nparallel',
                                 help = 'Number of parallel download, default is 10 parallel download.',)
-        self.parser.add_option( '--wait',
+        self.parser.add_argument( '--wait',
                                 dest = 'waittime',
                                 help = 'Increase the sendreceive-timeout in second',)
         getcommand.setOptions(self)

--- a/src/python/CRABClient/Commands/kill.py
+++ b/src/python/CRABClient/Commands/kill.py
@@ -50,7 +50,7 @@ class kill(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--killwarning',
+        self.parser.add_argument('--killwarning',
                                dest='killwarning',
                                default=None,
                                help='A warning message to be appended to the warnings list shown by "crab status"')

--- a/src/python/CRABClient/Commands/preparelocal.py
+++ b/src/python/CRABClient/Commands/preparelocal.py
@@ -147,13 +147,13 @@ sh ./CMSRunAnalysis.sh --jobId ${1}
 
         This allows to set specific command options
         """
-        self.parser.add_option("--jobid",
+        self.parser.add_argument("--jobid",
                                dest="jobid",
                                default=None,
-                               type="int",
+                               type=int,
                                help="Optional id of the job you want to execute locally")
 
-        self.parser.add_option("--destdir",
+        self.parser.add_argument("--destdir",
                                dest="destdir",
                                default=None,
                                help="Optional name of the directory to use, defaults to <projdir>/local")

--- a/src/python/CRABClient/Commands/recover.py
+++ b/src/python/CRABClient/Commands/recover.py
@@ -743,12 +743,12 @@ class recover(SubCommand):
         # --dir, --cmptask, --instance already added elsewhere:
 
         # step: recovery
-        self.parser.add_option("--strategy",
+        self.parser.add_argument("--strategy",
                                dest = "strategy",
                                default="notPublished",
                                help = "When using lumibased splitting, sets crab report --recovery option to this value")
 
-        self.parser.add_option("--destinstance",
+        self.parser.add_argument("--destinstance",
                                dest = "destinstance",
                                default = None,
                                help = "(Experimental) The CRABServer instance where you want to submit the recovery task to." +
@@ -758,7 +758,7 @@ class recover(SubCommand):
         # this option is to be considered experimental and useful for developers only
 
         # step: kill
-        self.parser.add_option("--forcekill",
+        self.parser.add_argument("--forcekill",
                         action="store_true", dest="forceKill", default=False,
                         help="Allows to kill failing task submitted by another user. Effective only for crab operators")
 

--- a/src/python/CRABClient/Commands/remake.py
+++ b/src/python/CRABClient/Commands/remake.py
@@ -60,7 +60,7 @@ class remake(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option("--task",
+        self.parser.add_argument("--task",
                                dest = "cmptask",
                                default = None,
                                help = "The complete task name. Can be taken from 'crab status' output, or from dashboard.")

--- a/src/python/CRABClient/Commands/remote_copy.py
+++ b/src/python/CRABClient/Commands/remote_copy.py
@@ -33,24 +33,24 @@ class remote_copy(SubCommand):
         This allows to set specific command options
         """
 
-        self.parser.add_option("--destination",
+        self.parser.add_argument("--destination",
                                dest = "destination",
                                default = None )
 
-        self.parser.add_option("--input",
+        self.parser.add_argument("--input",
                                dest = "inputdict",
                                default = None )
 
-        self.parser.add_option("--parallel",
+        self.parser.add_argument("--parallel",
                                dest = "nparallel")
 
-        self.parser.add_option("--wait",
+        self.parser.add_argument("--wait",
                                dest = "waittime")
 
-        self.parser.add_option("--checksum",
+        self.parser.add_argument("--checksum",
                                dest = "checksum")
 
-        self.parser.add_option("--command",
+        self.parser.add_argument("--command",
                                dest = "command")
 
 

--- a/src/python/CRABClient/Commands/report.py
+++ b/src/python/CRABClient/Commands/report.py
@@ -564,18 +564,18 @@ class report(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option("--outputdir",
+        self.parser.add_argument("--outputdir",
                                dest="outdir",
                                default=None,
                                help="Directory where to write the lumi summary files.")
 
-        self.parser.add_option("--recovery",
+        self.parser.add_argument("--recovery",
                                dest="recovery",
                                default="notFinished",
                                help="Strategy to calculate not processed lumis: notFinished," + \
                                       " notPublished or failed [default: %default].")
 
-        self.parser.add_option("--dbs",
+        self.parser.add_argument("--dbs",
                                dest="usedbs",
                                default=None,
                                help="Deprecated option removed in CRAB v3.3.1603.")

--- a/src/python/CRABClient/Commands/request_type.py
+++ b/src/python/CRABClient/Commands/request_type.py
@@ -22,7 +22,7 @@ class request_type(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option("--proxyfile",
+        self.parser.add_argument("--proxyfile",
                                dest="proxyfile",
                                default=None,
                                help="Proxy file to use.")

--- a/src/python/CRABClient/Commands/resubmit.py
+++ b/src/python/CRABClient/Commands/resubmit.py
@@ -191,46 +191,46 @@ class resubmit(SubCommand):
 
         This allows to set specific command options.
         """
-        self.parser.add_option('--jobids',
+        self.parser.add_argument('--jobids',
                                dest='jobids',
                                default=None,
                                help="The ids of the jobs to resubmit. Comma separated list of integers.",
                                metavar='JOBIDS')
 
-        self.parser.add_option('--sitewhitelist',
+        self.parser.add_argument('--sitewhitelist',
                                dest='sitewhitelist',
                                default=None,
                                help="Set the sites you want to whitelist for the resubmission." + \
                                       " Comma separated list of CMS site names (e.g.: T2_ES_CIEMAT,T2_IT_Rome[...]).")
 
-        self.parser.add_option('--siteblacklist',
+        self.parser.add_argument('--siteblacklist',
                                dest='siteblacklist',
                                default=None,
                                help="Set the sites you want to blacklist for the resubmission." + \
                                       " Comma separated list of CMS site names (e.g.: T2_ES_CIEMAT,T2_IT_Rome[...]).")
 
-        self.parser.add_option('--maxjobruntime',
+        self.parser.add_argument('--maxjobruntime',
                                dest='maxjobruntime',
                                default=None,
-                               type='int',
+                               type=int,
                                help="Set the maximum time (in minutes) jobs in this task are allowed to run." + \
                                       " Default is 1315 (21 hours 50 minutes).")
 
-        self.parser.add_option('--maxmemory',
+        self.parser.add_argument('--maxmemory',
                                dest='maxmemory',
                                default=None,
-                               type='int',
+                               type=int,
                                help="Set the maximum memory (in MB) used per job in this task." + \
                                       " Default is 2000.")
 
-        self.parser.add_option('--priority',
+        self.parser.add_argument('--priority',
                                dest='priority',
                                default=None,
-                               type='int',
+                               type=int,
                                help="Set the priority of this task compared to other tasks you own; tasks default to 10." + \
                                       " Tasks with higher priority values run first. This does not change your share compared to other users.")
 
-        self.parser.add_option('--publication',
+        self.parser.add_argument('--publication',
                                dest='publication',
                                default=False,
                                action='store_true',

--- a/src/python/CRABClient/Commands/setdatasetstatus.py
+++ b/src/python/CRABClient/Commands/setdatasetstatus.py
@@ -79,17 +79,17 @@ class setdatasetstatus(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--dbs-instance', dest='dbsInstance', default='prod/phys03',
+        self.parser.add_argument('--dbs-instance', dest='dbsInstance', default='prod/phys03',
                                help="DBS instance. e.g. prod/phys03 (default) or int/phys03 or full URL."
                                     + "\nUse at your own risk only if you really know what you are doing"
                                )
-        self.parser.add_option('--dataset', dest='dataset', default=None,
+        self.parser.add_argument('--dataset', dest='dataset', default=None,
                                help='dataset name')
-        self.parser.add_option('--status', dest='status', default=None,
+        self.parser.add_argument('--status', dest='status', default=None,
                                help="New status of the dataset: VALID/INVALID/DELETED/DEPRECATED",
                                choices=['VALID', 'INVALID', 'DELETED', 'DEPRECATED']
                                )
-        self.parser.add_option('--recursive', dest='recursive', default=False, action="store_true",
+        self.parser.add_argument('--recursive', dest='recursive', default=False, action="store_true",
                                help="Apply status to children datasets and sets all files status in those"
                                + "to VALID if status=VALID, INVALID otherwise"
                                )

--- a/src/python/CRABClient/Commands/setfilestatus.py
+++ b/src/python/CRABClient/Commands/setfilestatus.py
@@ -110,19 +110,19 @@ class setfilestatus(SubCommand):
 
         This allows to set specific command options
         """
-        self.parser.add_option('--dbs-instance', dest='dbsInstance', default='prod/phys03',
+        self.parser.add_argument('--dbs-instance', dest='dbsInstance', default='prod/phys03',
                                help="DBS instance. e.g. prod/phys03 (default) or int/phys03 or full URL."
                                     + "\nUse at your own risk only if you really know what you are doing"
                                )
-        self.parser.add_option('-d', '--dataset', dest='dataset', default=None,
+        self.parser.add_argument('-d', '--dataset', dest='dataset', default=None,
                                help='Will apply status to all files in this dataset.'
                                     + ' Use either --files or--dataset',
                                metavar='<dataset_name>')
-        self.parser.add_option('-s', '--status', dest='status', default=None,
+        self.parser.add_argument('-s', '--status', dest='status', default=None,
                                help='New status of the file(s): VALID/INVALID',
                                choices=['VALID', 'INVALID']
                                )
-        self.parser.add_option('-f', '--files', dest='files', default=None,
+        self.parser.add_argument('-f', '--files', dest='files', default=None,
                                help='List of files to be validated/invalidated.'
                                     + ' Can be either a simple LFN or a file containg LFNs or'
                                     + ' a comma separated list of LFNs. Use either --files or --dataset',

--- a/src/python/CRABClient/Commands/status.py
+++ b/src/python/CRABClient/Commands/status.py
@@ -1086,31 +1086,31 @@ class status(SubCommand):
         This allows to set specific command options
         """
 
-        self.parser.add_option("--long",
+        self.parser.add_argument("--long",
                                dest="long",
                                default=False,
                                action="store_true",
                                help="Print one status line per job.")
-        self.parser.add_option("--sort",
+        self.parser.add_argument("--sort",
                                dest="sort",
                                default=None,
                                help="Sort failed jobs by 'state', 'site', 'runtime', 'memory', 'cpu', 'retries', 'waste' or 'exitcode'.")
-        self.parser.add_option("--json",
+        self.parser.add_argument("--json",
                                dest="json",
                                default=False,
                                action="store_true",
                                help="Print status results in JSON format.")
-        self.parser.add_option("--summary",
+        self.parser.add_argument("--summary",
                                dest="summary",
                                default=False,
                                action="store_true",
                                help="Print site summary.")
-        self.parser.add_option("--verboseErrors",
+        self.parser.add_argument("--verboseErrors",
                                dest="verboseErrors",
                                default=False,
                                action="store_true",
                                help="Expand error summary, showing error messages for all failed jobs.")
-        self.parser.add_option("--jobids",
+        self.parser.add_argument("--jobids",
                                dest="jobids",
                                default=None,
                                help="The ids of jobs to print in crab status --long or --sort." + \

--- a/src/python/CRABClient/Commands/tasks.py
+++ b/src/python/CRABClient/Commands/tasks.py
@@ -75,20 +75,20 @@ task status does not progress beyond SUBMITTED unless the task is KILLED
         This allows to set specific command options
         """
 
-        self.parser.add_option('--fromdate',
+        self.parser.add_argument('--fromdate',
                                dest='fromdate',
                                default=None,
                                help='Give the user tasks since YYYY-MM-DD.',
                                metavar='YYYY-MM-DD')
 
-        self.parser.add_option('--days',
+        self.parser.add_argument('--days',
                                dest='days',
                                default=None,
-                               type='int',
+                               type=int,
                                help='Give the user tasks from the previous N days.',
                                metavar='N')
 
-        self.parser.add_option('--status',
+        self.parser.add_argument('--status',
                                dest='status',
                                default=None,
                                help='Give the user tasks with the given STATUS.',


### PR DESCRIPTION
Resolve https://github.com/dmwm/CRABClient/issues/5424

The hardest part is preserving the strict `disable_interspersed_args` behaviour and adding back the validating of unknown flags in [CRABOptParser.py](https://github.com/dmwm/CRABClient/pull/5425/changes#diff-7f3c43626918e298fd25bab96b58c98477c511f0d37dffb45064238daa34484c). 
*Thanks to LLM, helping me polish this part meanwhile we both looking at original [optparse.py](https://github.com/python/cpython/blob/dc12d1999b88e84d5a6b8e491be468b73379e54b/Lib/optparse.py#L1395C5-L1445C1)*

So, CRABOptParser in general + submit, createmyproxy subcommands will behave exactly the same.
*See also [the important bit disable_interspersed_args](https://docs.python.org/3/library/optparse.html#optparse.OptionParser.disable_interspersed_args)*

*P.S. Let me exhaustively test first (may write some unit-tests), do we already have test cases covered these behaviors?*
*P.S. Besides that, I think my proposed abstraction/structure is fairly minimal and clean. what do you think?*